### PR TITLE
Implement scout memory and exploration prioritization

### DIFF
--- a/ant_sim.py
+++ b/ant_sim.py
@@ -114,9 +114,35 @@ class WorkerAnt(BaseAnt):
 
 
 class ScoutAnt(BaseAnt):
-    """Ant that explores randomly, remembering its last position."""
+    """Ant that explores randomly, remembering visited positions."""
 
-    pass
+    def __init__(self, sim: "AntSim", x: int, y: int, color: str = "black") -> None:
+        super().__init__(sim, x, y, color)
+        self.visited: set[tuple[float, float]] = {(float(x), float(y))}
+
+    def update(self) -> None:
+        x1, y1, _, _ = self.sim.canvas.coords(self.item)
+
+        # Consider moves that lead to unexplored positions
+        moves = []
+        for dx in (-MOVE_STEP, 0, MOVE_STEP):
+            for dy in (-MOVE_STEP, 0, MOVE_STEP):
+                if dx == 0 and dy == 0:
+                    continue
+                new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
+                new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
+                if (new_x1, new_y1) not in self.visited:
+                    moves.append((dx, dy, new_x1, new_y1))
+
+        if moves:
+            dx, dy, new_x1, new_y1 = random.choice(moves)
+            self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+        else:
+            self.move_random()
+
+        coords = self.sim.canvas.coords(self.item)
+        self.last_pos = (coords[0], coords[1])
+        self.visited.add(self.last_pos)
 
 
 class Queen:

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import random
+
+from ant_sim import ScoutAnt, BaseAnt, MOVE_STEP, ANT_SIZE, WINDOW_WIDTH, WINDOW_HEIGHT
+
+
+class FakeCanvas:
+    def __init__(self):
+        self.objects = {}
+        self.next_id = 1
+
+    def _create_item(self, coords):
+        item_id = self.next_id
+        self.next_id += 1
+        self.objects[item_id] = coords[:]
+        return item_id
+
+    def create_oval(self, x1, y1, x2, y2, fill=None):
+        return self._create_item([x1, y1, x2, y2])
+
+    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+        return self._create_item([x1, y1, x2, y2])
+
+    def create_text(self, *args, **kwargs):
+        return self._create_item([0, 0, 0, 0])
+
+    def move(self, item_id, dx, dy):
+        x1, y1, x2, y2 = self.objects[item_id]
+        self.objects[item_id] = [x1 + dx, y1 + dy, x2 + dx, y2 + dy]
+
+    def coords(self, item_id):
+        return self.objects[item_id]
+
+    def itemconfigure(self, item_id, **kwargs):
+        pass
+
+
+class FakeSim:
+    def __init__(self):
+        self.canvas = FakeCanvas()
+
+
+def test_scout_records_positions(monkeypatch):
+    sim = FakeSim()
+    scout = ScoutAnt(sim, 0, 0)
+    assert (0.0, 0.0) in scout.visited
+
+    # choose first available unexplored move
+    monkeypatch.setattr(random, "choice", lambda opts: opts[0])
+    scout.update()
+
+    coords = sim.canvas.coords(scout.item)
+    assert (coords[0], coords[1]) in scout.visited
+    assert len(scout.visited) >= 2
+
+
+def test_scout_prioritizes_unexplored(monkeypatch):
+    sim = FakeSim()
+    scout = ScoutAnt(sim, 0, 0)
+
+    recorded = {}
+
+    def fake_choice(options):
+        recorded['options'] = options
+        return options[0]
+
+    monkeypatch.setattr(random, "choice", fake_choice)
+
+    # prevent fallback to move_random
+    called = {"move_random": False}
+
+    def fake_move_random(self):
+        called["move_random"] = True
+
+    monkeypatch.setattr(BaseAnt, "move_random", fake_move_random)
+
+    scout.update()
+
+    # ensure move_random was not used
+    assert not called["move_random"]
+    assert recorded["options"]
+    # options should be list of tuples (dx, dy, x, y)
+    assert isinstance(recorded["options"][0], tuple)
+    coords = sim.canvas.coords(scout.item)
+    assert (coords[0], coords[1]) in scout.visited


### PR DESCRIPTION
## Summary
- add visited set and exploration logic to `ScoutAnt`
- create tests for scout behavior

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667acc4f1c832eabedd2ca532dd416