### PR TITLE
Fix LICENSE formatting and cleanup README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,6 @@
 MIT License
-
-codex/add-license-file-and-update-readme
 Copyright (c) 2024 AI Ant Hive
-
 Copyright (c) 2024 AI Ant Hive contributors
-main
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Start the GUI with:
 ```bash
 python ant_sim.py
 ```
- main
 
 ## Development
 
@@ -42,7 +41,6 @@ python -m pytest
 
 ## License
 
-main
 
 ## License
 


### PR DESCRIPTION
## Summary
- clean up extraneous lines in `LICENSE`
- remove stray `main` lines from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686686d8aea4832e87deecdf9cf9c131