### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,9 @@ the number of active ants.
 ## Setup
 
 1. Install **Python 3.11** or newer.
- codex/update-readme-on-environment-variables
 2. Install dependencies with `pip install -r requirements.txt`.
 3. Environment variables can be loaded from a `.env` file via `python-dotenv`, though none are required for basic usage.
 4. Start the GUI using `python ant_sim.py`.
-
-2. Install the required dependencies:
-
-   ```bash
-   python -m pip install -r requirements.txt
-   ```
 
 ## Running the simulation
 
@@ -28,7 +21,6 @@ Start the GUI with:
 ```bash
 python ant_sim.py
 ```
- main
 
 ## Development
 
@@ -37,18 +29,9 @@ The `tests` folder contains a small test suite. Run it with:
 ```bash
 python -m pytest
 ```
-73jotk-codex/expand-readme-with-setup-and-usage-instructions
 
-
-## License
-
-main
 
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-
-## License
-
-AI Ant Hive is licensed under the [MIT License](LICENSE).
 


### PR DESCRIPTION
## Summary
- clean up README by removing leftover branch lines
- deduplicate setup instructions
- keep one license section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686686d96eb4832e8c7dd725a462d921