### PR TITLE
Improve terrain rendering with textures

### DIFF
--- a/ant_sim.py
+++ b/ant_sim.py
@@ -28,6 +28,23 @@ TILE_TUNNEL = "tunnel"
 TILE_ROCK = "rock"
 TILE_COLLAPSED = "collapsed"
 
+# Small base64 encoded textures to avoid binary files in the repository
+SAND_TEXTURE = (
+    "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAARklEQVR4nO3QMRHAMBADwctjEPRg"
+    "MgSjEAenyJiArfLVqdninjneZZs9Sdz8SmKSqCRm+wdTGEAlMeiGCbwbdsOD3w3v8Q8txS8qFa7u"
+    "XQAAAABJRU5ErkJggg=="
+)
+TUNNEL_TEXTURE = (
+    "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAARklEQVR4nO3QMRHAMBADwctjEIsg"
+    "NA/DFAenyJiArfLVqdninjneZZs9Sdz8SmKSqCRm+wdTGEAlMeiGCbwbdsOD3w3v8Q8OIi4y+xWE"
+    "tQAAAABJRU5ErkJggg=="
+)
+ROCK_TEXTURE = (
+    "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAQklEQVR4nO3QsRHAQAwCwbNqoHO1"
+    "SQ/+4McNWIQiI9ngnu5+bfNNEpNfSUwSlcRsXzCFAVQSg22YwLfhNvzxt+EcPz04LrP+YyCNAAAA"
+    "AElFTkSuQmCC"
+)
+
 class Terrain:
     """Simple 2D grid representing the underground."""
 
@@ -38,28 +55,75 @@ class Terrain:
         TILE_COLLAPSED: "black",
     }
 
+    texture_data = {
+        TILE_SAND: SAND_TEXTURE,
+        TILE_TUNNEL: TUNNEL_TEXTURE,
+        TILE_ROCK: ROCK_TEXTURE,
+    }
+
     def __init__(self, width: int, height: int, canvas: tk.Canvas) -> None:
         self.width = width
         self.height = height
         self.canvas = canvas
+        self.images: dict[str, tk.PhotoImage | None] = {}
+        for key, data in self.texture_data.items():
+            try:
+                self.images[key] = tk.PhotoImage(data=data)
+            except Exception:
+                # When running headless tests there may be no Tk instance
+                self.images[key] = None
         self.grid: list[list[str]] = [
             [TILE_SAND for _ in range(height)] for _ in range(width)
         ]
         self.rects: list[list[int]] = [[0] * height for _ in range(width)]
+        self.shades: list[list[int]] = [[0] * height for _ in range(width)]
         self._render()
 
     def _render(self) -> None:
         for x in range(self.width):
             for y in range(self.height):
                 state = self.grid[x][y]
-                rect = self.canvas.create_rectangle(
+                if hasattr(self.canvas, "create_image") and self.images.get(state):
+                    rect = self.canvas.create_image(
+                        x * TILE_SIZE,
+                        y * TILE_SIZE,
+                        anchor="nw",
+                        image=self.images[state],
+                    )
+                else:
+                    rect = self.canvas.create_rectangle(
+                        x * TILE_SIZE,
+                        y * TILE_SIZE,
+                        (x + 1) * TILE_SIZE,
+                        (y + 1) * TILE_SIZE,
+                        fill=self.colors[state],
+                    )
+                self.rects[x][y] = rect
+                self._update_shading(x, y)
+
+    def _update_shading(self, x: int, y: int) -> None:
+        """Add a semi-transparent overlay on tunnel edges."""
+        if self.shades[x][y]:
+            if hasattr(self.canvas, "delete"):
+                self.canvas.delete(self.shades[x][y])
+            self.shades[x][y] = 0
+
+        state = self.grid[x][y]
+        if state != TILE_TUNNEL:
+            return
+
+        # Determine if any neighbour is non-tunnel
+        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+            nx, ny = x + dx, y + dy
+            if self.get_cell(nx, ny) != TILE_TUNNEL:
+                self.shades[x][y] = self.canvas.create_rectangle(
                     x * TILE_SIZE,
                     y * TILE_SIZE,
                     (x + 1) * TILE_SIZE,
                     (y + 1) * TILE_SIZE,
-                    fill=self.colors[state],
+                    fill="#00000040",
                 )
-                self.rects[x][y] = rect
+                break
 
     def get_cell(self, x: int, y: int) -> str:
         if x < 0 or y < 0 or x >= self.width or y >= self.height:
@@ -69,7 +133,30 @@ class Terrain:
     def set_cell(self, x: int, y: int, state: str) -> None:
         if 0 <= x < self.width and 0 <= y < self.height:
             self.grid[x][y] = state
-            self.canvas.itemconfigure(self.rects[x][y], fill=self.colors[state])
+            if hasattr(self.canvas, "delete"):
+                self.canvas.delete(self.rects[x][y])
+                if self.shades[x][y]:
+                    self.canvas.delete(self.shades[x][y])
+            if hasattr(self.canvas, "create_image") and self.images.get(state):
+                self.rects[x][y] = self.canvas.create_image(
+                    x * TILE_SIZE,
+                    y * TILE_SIZE,
+                    anchor="nw",
+                    image=self.images[state],
+                )
+            else:
+                self.rects[x][y] = self.canvas.create_rectangle(
+                    x * TILE_SIZE,
+                    y * TILE_SIZE,
+                    (x + 1) * TILE_SIZE,
+                    (y + 1) * TILE_SIZE,
+                    fill=self.colors[state],
+                )
+            self._update_shading(x, y)
+            for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < self.width and 0 <= ny < self.height:
+                    self._update_shading(nx, ny)
 
 # Energy constants
 ENERGY_MAX = 100


### PR DESCRIPTION
## Summary
- add texture PNGs for sand, tunnel, and rock
- render terrain with `create_image` when possible
- overlay semi-transparent rectangles on tunnel edges for depth
- refresh overlay in `set_cell`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866bd44aad4832e810f7840a76e59e3