### PR TITLE
Add animated sprite ants with visual effects

### DIFF
--- a/ant_sim.py
+++ b/ant_sim.py
@@ -20,6 +20,30 @@ MOVE_STEP = 5
 PHEROMONE_DECAY = 0.01
 SCOUT_PHEROMONE_AMOUNT = 1.0
 
+# Animated sprite frames for ants. We avoid external binaries by generating
+# simple images programmatically. When Tk isn't available (e.g. during tests)
+# creation will fail and we fall back to `None` frames.
+def _load_sprites() -> list[tk.PhotoImage | None]:
+    try:
+        frames: list[tk.PhotoImage] = []
+        for i in range(2):
+            img = tk.PhotoImage(width=ANT_SIZE, height=ANT_SIZE)
+            body_color = "brown"
+            for x in range(ANT_SIZE):
+                for y in range(ANT_SIZE):
+                    if 2 <= x < ANT_SIZE - 2 and 2 <= y < ANT_SIZE - 2:
+                        img.put(body_color, (x, y))
+            leg_y = ANT_SIZE - 2 + (0 if i == 0 else -1)
+            img.put("black", (1, leg_y))
+            img.put("black", (ANT_SIZE - 2, leg_y))
+            frames.append(img)
+        return frames
+    except Exception:
+        # During headless testing Tk may not be initialized.
+        return [None, None]
+
+ANT_SPRITES = _load_sprites()
+
 
 # Terrain constants
 TILE_SIZE = 20
@@ -107,9 +131,23 @@ class BaseAnt:
         self, sim: "AntSim", x: int, y: int, color: str = "black", energy: int = 100
     ) -> None:
         self.sim = sim
-        self.item: int = sim.canvas.create_oval(
-            x, y, x + ANT_SIZE, y + ANT_SIZE, fill=color
+        self.color = color
+        self.item: int = sim.canvas.create_rectangle(
+            x,
+            y,
+            x + ANT_SIZE,
+            y + ANT_SIZE,
+            outline="",
+            fill="",
         )
+        self.image_id: int = sim.canvas.create_image(
+            x,
+            y,
+            image=ANT_SPRITES[0],
+            anchor="nw",
+        )
+        self.sprite_frames = ANT_SPRITES
+        self.frame_index = 0
         self.carrying_food: bool = False
         self.energy: float = min(ENERGY_MAX, energy)
         self.status: str = "Active"
@@ -140,7 +178,10 @@ class BaseAnt:
         if self.energy < cost:
             return
         self.energy -= cost
-        self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+        dx_move = new_x1 - x1
+        dy_move = new_y1 - y1
+        self.sim.canvas.move(self.item, dx_move, dy_move)
+        self.sim.canvas.move(self.image_id, dx_move, dy_move)
 
     def move_random(self) -> None:
         dx = random.choice([-MOVE_STEP, 0, MOVE_STEP])
@@ -174,6 +215,8 @@ class BaseAnt:
         self.move_random()
         coords = self.sim.canvas.coords(self.item)
         self.last_pos = (coords[0], coords[1])
+        self.frame_index = (self.frame_index + 1) % len(self.sprite_frames)
+        self.sim.canvas.itemconfigure(self.image_id, image=self.sprite_frames[self.frame_index])
 
 
 class AIBaseAnt(BaseAnt):
@@ -242,6 +285,7 @@ class WorkerAnt(BaseAnt):
             coords = self.sim.canvas.coords(self.item)
             self.last_pos = (coords[0], coords[1])
             return
+        start = self.sim.canvas.coords(self.item)
         if not self.carrying_food:
             # Check for food drops first
             for drop in getattr(self.sim, "food_drops", []):
@@ -249,6 +293,9 @@ class WorkerAnt(BaseAnt):
                     if drop.take_charge():
                         self.energy = min(ENERGY_MAX, self.energy + 20)
                         self.carrying_food = True
+                        cx = start[0] + ANT_SIZE / 2
+                        cy = start[1] + ANT_SIZE / 2
+                        self.sim.sparkle(cx, cy)
                     if drop.charges <= 0:
                         self.sim.food_drops.remove(drop)
                     break
@@ -272,12 +319,16 @@ class WorkerAnt(BaseAnt):
 
             if best_value > 0 and best_dir is not None:
                 self.sim.canvas.move(self.item, best_dir[0], best_dir[1])
+                self.sim.canvas.move(self.image_id, best_dir[0], best_dir[1])
             else:
                 self.move_towards(self.sim.food)
             if self.sim.check_collision(self.item, self.sim.food):
                 self.carrying_food = True
                 self.sim.food_collected += 1
                 self.sim.move_food()
+                cx = start[0] + ANT_SIZE / 2
+                cy = start[1] + ANT_SIZE / 2
+                self.sim.sparkle(cx, cy)
         else:
             self.move_towards(self.sim.queen.item)
             if self.sim.check_collision(self.item, self.sim.queen.item):
@@ -285,7 +336,18 @@ class WorkerAnt(BaseAnt):
                 self.sim.queen.fed += 1
                 self.sim.queen_fed += 1
                 self.carrying_food = False
+                coords = self.sim.canvas.coords(self.item)
+                cx = coords[0] + ANT_SIZE / 2
+                cy = coords[1] + ANT_SIZE / 2
+                self.sim.sparkle(cx, cy)
         coords = self.sim.canvas.coords(self.item)
+        if coords[:2] != start[:2]:
+            x1 = start[0] + ANT_SIZE / 2
+            y1 = start[1] + ANT_SIZE / 2
+            x2 = coords[0] + ANT_SIZE / 2
+            y2 = coords[1] + ANT_SIZE / 2
+            trail = self.sim.canvas.create_line(x1, y1, x2, y2, fill=self.color)
+            self.sim.canvas.after(300, lambda t=trail: self.sim.canvas.delete(t))
         self.last_pos = (coords[0], coords[1])
 
 
@@ -563,6 +625,10 @@ class AntSim:
 
     def move_food(self) -> None:
         self.canvas.move(self.food, random.randint(-50, 50), random.randint(20, 40))
+
+    def sparkle(self, x: float, y: float) -> None:
+        flash = self.canvas.create_oval(x - 3, y - 3, x + 3, y + 3, fill="yellow", outline="")
+        self.canvas.after(200, lambda: self.canvas.delete(flash))
 
     def start_place_food(self, _event) -> None:
         self.placing_food = True

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -3,6 +3,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+from ant_sim import ANT_SIZE
+
 
 # We'll use a minimal fake canvas to test collision without requiring Tk
 
@@ -17,14 +19,27 @@ class FakeCanvas:
         self.objects[item_id] = coords[:]
         return item_id
 
-    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
-    def create_oval(self, x1, y1, x2, y2, fill=None):
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
     def create_text(self, *args, **kwargs):
         return self._create_item([0, 0, 0, 0])
+
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        return self._create_item([x1, y1, x2, y2])
+
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+
+    def after(self, delay, func=None):
+        if func:
+            func()
 
     def move(self, item_id, dx, dy):
         x1, y1, x2, y2 = self.objects[item_id]

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -10,6 +10,7 @@ from ant_sim import (
     DIG_ENERGY_COST,
     REST_ENERGY_GAIN,
     ENERGY_MAX,
+    ANT_SIZE,
 )
 
 
@@ -24,14 +25,27 @@ class FakeCanvas:
         self.objects[item_id] = coords[:]
         return item_id
 
-    def create_oval(self, x1, y1, x2, y2, fill=None):
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
-    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
     def create_text(self, *args, **kwargs):
         return self._create_item([0, 0, 0, 0])
+
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        return self._create_item([x1, y1, x2, y2])
+
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+
+    def after(self, delay, func=None):
+        if func:
+            func()
 
     def move(self, item_id, dx, dy):
         x1, y1, x2, y2 = self.objects[item_id]

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -28,14 +28,27 @@ class FakeCanvas:
         self.objects[item_id] = coords[:]
         return item_id
 
-    def create_oval(self, x1, y1, x2, y2, fill=None):
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
-    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
     def create_text(self, *args, **kwargs):
         return self._create_item([0, 0, 0, 0])
+
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        return self._create_item([x1, y1, x2, y2])
+
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+
+    def after(self, delay, func=None):
+        if func:
+            func()
 
     def move(self, item_id, dx, dy):
         x1, y1, x2, y2 = self.objects[item_id]

--- a/tests/test_pheromone.py
+++ b/tests/test_pheromone.py
@@ -24,14 +24,27 @@ class FakeCanvas:
         self.objects[item_id] = coords[:]
         return item_id
 
-    def create_oval(self, x1, y1, x2, y2, fill=None):
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
-    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
     def create_text(self, *args, **kwargs):
         return self._create_item([0, 0, 0, 0])
+
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        return self._create_item([x1, y1, x2, y2])
+
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+
+    def after(self, delay, func=None):
+        if func:
+            func()
 
     def move(self, item_id, dx, dy):
         x1, y1, x2, y2 = self.objects[item_id]

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -20,14 +20,27 @@ class FakeCanvas:
         self.objects[item_id] = coords[:]
         return item_id
 
-    def create_oval(self, x1, y1, x2, y2, fill=None):
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
-    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
     def create_text(self, *args, **kwargs):
         return self._create_item([0, 0, 0, 0])
+
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        return self._create_item([x1, y1, x2, y2])
+
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+
+    def after(self, delay, func=None):
+        if func:
+            func()
 
     def move(self, item_id, dx, dy):
         x1, y1, x2, y2 = self.objects[item_id]
@@ -50,6 +63,9 @@ class FakeSim:
         self.queen = Queen(self, 0, 0)
 
     def move_food(self):
+        pass
+
+    def sparkle(self, x, y):
         pass
 
     def get_coords(self, item):

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -18,14 +18,27 @@ class FakeCanvas:
         self.objects[item_id] = coords[:]
         return item_id
 
-    def create_oval(self, x1, y1, x2, y2, fill=None):
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
-    def create_rectangle(self, x1, y1, x2, y2, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kwargs):
         return self._create_item([x1, y1, x2, y2])
 
     def create_text(self, *args, **kwargs):
         return self._create_item([0, 0, 0, 0])
+
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        return self._create_item([x1, y1, x2, y2])
+
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+
+    def after(self, delay, func=None):
+        if func:
+            func()
 
     def move(self, item_id, dx, dy):
         x1, y1, x2, y2 = self.objects[item_id]


### PR DESCRIPTION
## Summary
- replace oval ants with sprite-based images
- animate ants by cycling through sprite frames
- show pheromone trail lines when workers move
- add sparkle effect on food pickup and delivery
- generate ant sprite frames with tkinter instead of binary GIF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bd52ccec832e99a5b7769a6b8018