### PR TITLE
Implement neural spider AI with vitality and hunger

### DIFF
--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -9,7 +9,6 @@ from ant_sim import (
     MOVE_ENERGY_COST,
     DIG_ENERGY_COST,
     REST_ENERGY_GAIN,
-    ENERGY_MAX,
     ANT_SIZE,
 )
 

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -13,7 +13,6 @@ from ant_sim import (
     Terrain,
     TILE_SIZE,
     TILE_TUNNEL,
-    TILE_SAND,
 )
 
 

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -114,8 +114,8 @@ def test_worker_feeds_queen():
     assert not worker.carrying_food
 
 def test_queen_spawns_new_worker():
-    sim = FakeSim()
-    # Add actual test logic here if needed
+    FakeSim()
+    # This placeholder test simply ensures construction succeeds
 
 @patch("ant_sim.openai.ChatCompletion.create")
 def test_ai_base_ant_moves_with_openai(mock_create):


### PR DESCRIPTION
## Summary
- give spider a simple neural-network brain
- add vitality and hunger bars
- spider hunger increases every three kills
- adjust tests for linting and add new spider tests

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e42a1290832e859bc5d633899550