### PR TITLE
Refactor ant simulation into modular package

### DIFF
--- a/ant_hive/__init__.py
+++ b/ant_hive/__init__.py
@@ -1,0 +1,7 @@
+from .constants import *
+from .terrain import *
+from .sprites import *
+from .ai_interface import openai
+from . import entities
+from .entities import *
+from .sim import AntSim

--- a/ant_hive/ai_interface.py
+++ b/ant_hive/ai_interface.py
@@ -1,0 +1,29 @@
+import os
+
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    class _DummyChat:
+        @staticmethod
+        def create(*_args, **_kwargs):
+            raise ModuleNotFoundError("openai is required for this feature")
+
+    class _DummyOpenAI:
+        api_key = ""
+        ChatCompletion = _DummyChat
+
+    openai = _DummyOpenAI()
+
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
+
+
+def chat_completion(messages: list[dict], model: str, max_tokens: int = 20) -> str | None:
+    try:
+        resp = openai.ChatCompletion.create(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+        )
+        return resp.choices[0].message["content"].strip()
+    except Exception:
+        return None

--- a/ant_hive/constants.py
+++ b/ant_hive/constants.py
@@ -1,0 +1,28 @@
+PALETTE = {
+    "background": "#f4ecd8",
+    "sidebar": "#eee1c6",
+    "frame": "#d2b48c",
+    "bar_bg": "#5a462e",
+    "bar_green": "#4caf50",
+    "bar_yellow": "#c4b000",
+    "bar_red": "#8b0000",
+    "neon_purple": "#d400ff",
+}
+
+MONO_FONT = ("JetBrains Mono", 10)
+HEADER_FONT = ("JetBrains Mono", 10, "bold underline")
+
+WINDOW_WIDTH = 400
+WINDOW_HEIGHT = 600
+SIDEBAR_WIDTH = 150
+ANT_SIZE = 10
+FOOD_SIZE = 8
+MOVE_STEP = 5
+TILE_SIZE = 20
+PHEROMONE_DECAY = 0.01
+SCOUT_PHEROMONE_AMOUNT = 1.0
+
+ENERGY_MAX = 100
+MOVE_ENERGY_COST = 1
+DIG_ENERGY_COST = 2
+REST_ENERGY_GAIN = 5

--- a/ant_hive/entities/__init__.py
+++ b/ant_hive/entities/__init__.py
@@ -1,0 +1,23 @@
+from .base_ant import BaseAnt, AIBaseAnt
+from .worker import WorkerAnt
+from .scout import ScoutAnt
+from .soldier import SoldierAnt
+from .nurse import NurseAnt
+from .queen import Queen
+from .spider import Spider, SpiderBrain
+from .egg import Egg
+from .food import FoodDrop
+
+__all__ = [
+    "BaseAnt",
+    "AIBaseAnt",
+    "WorkerAnt",
+    "ScoutAnt",
+    "SoldierAnt",
+    "NurseAnt",
+    "Queen",
+    "Spider",
+    "SpiderBrain",
+    "Egg",
+    "FoodDrop",
+]

--- a/ant_hive/entities/base_ant.py
+++ b/ant_hive/entities/base_ant.py
@@ -1,0 +1,195 @@
+import json
+import os
+import random
+from typing import Tuple
+
+import tkinter as tk
+
+from ..constants import (
+    ANT_SIZE,
+    ENERGY_MAX,
+    MOVE_ENERGY_COST,
+    DIG_ENERGY_COST,
+    REST_ENERGY_GAIN,
+    MOVE_STEP,
+    WINDOW_WIDTH,
+    WINDOW_HEIGHT,
+)
+from ..sprites import ANT_SPRITES
+from ..terrain import (
+    Terrain,
+    TILE_SIZE,
+    TILE_SAND,
+    TILE_TUNNEL,
+    TILE_ROCK,
+    TILE_COLLAPSED,
+)
+from ..ai_interface import chat_completion
+
+
+class BaseAnt:
+    def __init__(self, sim: "AntSim", x: int, y: int, color: str = "black", energy: int = 100) -> None:
+        self.sim = sim
+        self.color = color
+        self.item: int = sim.canvas.create_rectangle(
+            x,
+            y,
+            x + ANT_SIZE,
+            y + ANT_SIZE,
+            outline="",
+            fill="",
+        )
+        self.image_id = sim.canvas.create_image(
+            x,
+            y,
+            image=ANT_SPRITES[0],
+            anchor="nw",
+        )
+        self.sprite_frames = ANT_SPRITES
+        self.frame_index = 0
+
+        self.energy_bar_bg = sim.canvas.create_rectangle(
+            x,
+            y + 4,
+            x + ANT_SIZE,
+            y + 2,
+            fill=self.sim.PALETTE["bar_bg"] if hasattr(self.sim, "PALETTE") else "#5a462e",
+        )
+        self.energy_bar = sim.canvas.create_rectangle(
+            x,
+            y + 4,
+            x + ANT_SIZE,
+            y + 2,
+            fill=self.sim.PALETTE.get("bar_green", "#4caf50") if hasattr(self.sim, "PALETTE") else "#4caf50",
+        )
+
+        self.carrying_food: bool = False
+        self.energy: float = min(ENERGY_MAX, energy)
+        self.status: str = "Active"
+        self.role: str = self.__class__.__name__
+        self.ant_id: int = self.item
+        self.terrain: Terrain | None = getattr(sim, "terrain", None)
+
+    def attempt_move(self, dx: int, dy: int) -> None:
+        if self.energy <= 0:
+            return
+        x1, y1, _, _ = self.sim.canvas.coords(self.item)
+        new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
+        new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
+
+        cost = MOVE_ENERGY_COST
+        if self.terrain:
+            tile_x = int((new_x1 + ANT_SIZE / 2) // TILE_SIZE)
+            tile_y = int((new_y1 + ANT_SIZE / 2) // TILE_SIZE)
+            tile = self.terrain.get_cell(tile_x, tile_y)
+            if tile in (TILE_ROCK, TILE_COLLAPSED):
+                return
+            if tile == TILE_SAND:
+                self.terrain.set_cell(tile_x, tile_y, TILE_TUNNEL)
+                cost += 1
+        if self.energy < cost:
+            return
+        self.energy -= cost
+        dx_move = new_x1 - x1
+        dy_move = new_y1 - y1
+        self.sim.canvas.move(self.item, dx_move, dy_move)
+        self.sim.canvas.move(self.image_id, dx_move, dy_move)
+
+    def move_random(self) -> None:
+        dx = random.choice([-MOVE_STEP, 0, MOVE_STEP])
+        dy = random.choice([-MOVE_STEP, 0, MOVE_STEP])
+        self.attempt_move(dx, dy)
+
+    def move_towards(self, target: int) -> None:
+        x1, y1, _, _ = self.sim.canvas.coords(self.item)
+        tx1, ty1, _, _ = self.sim.canvas.coords(target)
+        dx = MOVE_STEP if x1 < tx1 else -MOVE_STEP if x1 > tx1 else 0
+        dy = MOVE_STEP if y1 < ty1 else -MOVE_STEP if y1 > ty1 else 0
+        self.attempt_move(dx, dy)
+
+    def consume_energy(self, amount: int) -> None:
+        self.energy = max(0, self.energy - amount)
+
+    def rest(self) -> None:
+        self.energy = min(ENERGY_MAX, self.energy + REST_ENERGY_GAIN)
+
+    def dig(self) -> None:
+        self.consume_energy(DIG_ENERGY_COST)
+
+    def energy_color(self) -> str:
+        if self.energy > 60:
+            return self.sim.PALETTE.get("bar_green", "#4caf50")
+        if self.energy > 30:
+            return self.sim.PALETTE.get("bar_yellow", "#c4b000")
+        return self.sim.PALETTE.get("bar_red", "#8b0000")
+
+    def update_energy_bar(self) -> None:
+        x1, y1, x2, _ = self.sim.canvas.coords(self.item)
+        self._set_coords(self.energy_bar_bg, x1, y1 - 4, x2, y1 - 2)
+        width = (self.energy / ENERGY_MAX) * (x2 - x1)
+        self._set_coords(self.energy_bar, x1, y1 - 4, x1 + width, y1 - 2)
+        self.sim.canvas.itemconfigure(self.energy_bar, fill=self.energy_color())
+
+    def _set_coords(self, item: int, x1: float, y1: float, x2: float, y2: float) -> None:
+        try:
+            self.sim.canvas.coords(item, x1, y1, x2, y2)
+        except TypeError:
+            if hasattr(self.sim.canvas, "objects"):
+                self.sim.canvas.objects[item] = [x1, y1, x2, y2]
+
+    def update(self) -> None:
+        if self.energy <= 0:
+            self.status = "Tired"
+            self.energy = max(0, self.energy - 0.1)
+            self.rest()
+            return
+
+        self.move_random()
+        coords = self.sim.canvas.coords(self.item)
+        self.last_pos = (coords[0], coords[1])
+        self.frame_index = (self.frame_index + 1) % len(self.sprite_frames)
+        self.sim.canvas.itemconfigure(self.image_id, image=self.sprite_frames[self.frame_index])
+
+
+class AIBaseAnt(BaseAnt):
+    """Ant that decides movement using the OpenAI API."""
+
+    def __init__(self, sim: "AntSim", x: int, y: int, color: str = "black", model: str | None = None) -> None:
+        super().__init__(sim, x, y, color)
+        self.model = model or os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+    def get_ai_move(self) -> Tuple[int, int]:
+        key = os.getenv("OPENAI_API_KEY")
+        if not key:
+            return random.choice([-MOVE_STEP, 0, MOVE_STEP]), random.choice([-MOVE_STEP, 0, MOVE_STEP])
+        state = {
+            "ant": self.sim.canvas.coords(self.item),
+            "food": self.sim.canvas.coords(self.sim.food),
+            "queen": self.sim.canvas.coords(self.sim.queen.item),
+        }
+        messages = [
+            {
+                "role": "system",
+                "content": 'You control an ant in a grid. Respond with JSON like {"dx":5,"dy":0}.',
+            },
+            {"role": "user", "content": json.dumps(state)},
+        ]
+        result = chat_completion(messages, self.model, 10)
+        if result:
+            try:
+                data = json.loads(result)
+                return int(data.get("dx", 0)), int(data.get("dy", 0))
+            except Exception:
+                pass
+        return 0, 0
+
+    def update(self) -> None:
+        if self.energy <= 0:
+            self.rest()
+            coords = self.sim.canvas.coords(self.item)
+            self.last_pos = (coords[0], coords[1])
+            return
+        dx, dy = self.get_ai_move()
+        self.attempt_move(dx, dy)
+        coords = self.sim.canvas.coords(self.item)
+        self.last_pos = (coords[0], coords[1])

--- a/ant_hive/entities/egg.py
+++ b/ant_hive/entities/egg.py
@@ -1,0 +1,19 @@
+from ..constants import ANT_SIZE
+from .worker import WorkerAnt
+
+
+class Egg:
+    """Represents an egg that will hatch into a new worker ant."""
+
+    def __init__(self, sim: "AntSim", x: int, y: int, hatch_time: int = 200) -> None:
+        self.sim = sim
+        self.hatch_time = hatch_time
+        self.item = sim.canvas.create_oval(x, y, x + ANT_SIZE, y + ANT_SIZE, fill="white")
+
+    def update(self) -> None:
+        self.hatch_time -= 1
+        if self.hatch_time <= 0:
+            x1, y1, _, _ = self.sim.canvas.coords(self.item)
+            self.sim.canvas.delete(self.item)
+            self.sim.eggs.remove(self)
+            self.sim.ants.append(WorkerAnt(self.sim, int(x1), int(y1), "blue"))

--- a/ant_hive/entities/food.py
+++ b/ant_hive/entities/food.py
@@ -1,0 +1,73 @@
+from ..constants import FOOD_SIZE
+from ..sprites import create_glowing_icon
+
+
+class FoodDrop:
+    """Limited food source that disappears after its charges are used."""
+
+    def __init__(self, sim: "AntSim", x: int, y: int, charges: int = 5) -> None:
+        self.sim = sim
+        self.charges = charges
+        self.item = sim.canvas.create_rectangle(
+            x,
+            y,
+            x + FOOD_SIZE,
+            y + FOOD_SIZE,
+            outline="",
+            fill="",
+        )
+
+        self.icon = None
+        self.flash_icon = None
+        self.image_item = None
+        self.tooltip = None
+
+        if hasattr(sim.canvas, "create_image"):
+            self.icon = create_glowing_icon(FOOD_SIZE)
+            self.flash_icon = create_glowing_icon(FOOD_SIZE, inner="#ffffff", outer="#ffcc00")
+            self.image_item = sim.canvas.create_image(x, y, image=self.icon, anchor="nw")
+            self.tooltip = sim.canvas.create_text(
+                x + FOOD_SIZE / 2,
+                y - 10,
+                text=f"{self.charges} left",
+                state="hidden",
+                fill="black",
+                font=("Arial", 8),
+            )
+            sim.canvas.tag_bind(self.image_item, "<Enter>", self._show_tooltip)
+            sim.canvas.tag_bind(self.image_item, "<Leave>", self._hide_tooltip)
+            sim.canvas.tag_bind(self.image_item, "<Button-1>", self._on_click)
+
+    def _show_tooltip(self, _event=None) -> None:
+        if self.tooltip is not None:
+            self.sim.canvas.itemconfigure(self.tooltip, state="normal")
+
+    def _hide_tooltip(self, _event=None) -> None:
+        if self.tooltip is not None:
+            self.sim.canvas.itemconfigure(self.tooltip, state="hidden")
+
+    def _flash(self) -> None:
+        if self.image_item and self.flash_icon:
+            self.sim.canvas.itemconfigure(self.image_item, image=self.flash_icon)
+            if hasattr(self.sim, "master") and hasattr(self.sim.master, "after"):
+                self.sim.master.after(
+                    100, lambda: self.sim.canvas.itemconfigure(self.image_item, image=self.icon)
+                )
+
+    def _on_click(self, _event=None) -> None:
+        self.take_charge()
+
+    def take_charge(self) -> bool:
+        if self.charges <= 0:
+            return False
+        self.charges -= 1
+        self._flash()
+        if self.tooltip is not None:
+            self.sim.canvas.itemconfigure(self.tooltip, text=f"{self.charges} left")
+        if self.charges <= 0:
+            self.sim.canvas.delete(self.item)
+            if self.image_item:
+                self.sim.canvas.delete(self.image_item)
+            if self.tooltip:
+                self.sim.canvas.delete(self.tooltip)
+        return True

--- a/ant_hive/entities/nurse.py
+++ b/ant_hive/entities/nurse.py
@@ -1,0 +1,24 @@
+import random
+
+from ..constants import ANT_SIZE
+from .base_ant import BaseAnt
+
+
+class NurseAnt(BaseAnt):
+    """Ant that tends to the queen, feeding her when nearby."""
+
+    def update(self) -> None:
+        if self.energy <= 0:
+            self.rest()
+        else:
+            self.move_towards(self.sim.queen.item)
+            if self.sim.check_collision(self.item, self.sim.queen.item):
+                self.sim.queen.feed()
+                if hasattr(self.sim, "queen_fed"):
+                    self.sim.queen.fed += 1
+                    self.sim.queen_fed += 1
+                if random.random() < 0.3:
+                    qx1, qy1, _, _ = self.sim.canvas.coords(self.sim.queen.item)
+                    self.sim.queen.lay_egg(int(qx1 + 20), int(qy1))
+        coords = self.sim.canvas.coords(self.item)
+        self.last_pos = (coords[0], coords[1])

--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -1,0 +1,182 @@
+import json
+import os
+import random
+import tkinter as tk
+
+from ..constants import ANT_SIZE, WINDOW_WIDTH, WINDOW_HEIGHT, PALETTE, MOVE_STEP
+from ..ai_interface import chat_completion, openai
+from .egg import Egg
+from .worker import WorkerAnt
+from .base_ant import BaseAnt
+
+
+class Queen:
+    """Represents the colony's queen. Uses OpenAI for spawn decisions."""
+
+    def __init__(self, sim: "AntSim", x: int, y: int, model: str | None = None) -> None:
+        self.sim = sim
+        self.item: int = sim.canvas.create_oval(x, y, x + 40, y + 20, fill=PALETTE["neon_purple"])
+        self.hunger_bar_bg = sim.canvas.create_rectangle(x, y - 6, x + 40, y - 4, fill=PALETTE["bar_bg"])
+        self.hunger_bar = sim.canvas.create_rectangle(x, y - 6, x + 40, y - 4, fill=PALETTE["bar_green"])
+        self.hunger: float = 100
+        self.spawn_timer: int = 300
+        self.model = model or os.getenv("OPENAI_QUEEN_MODEL", "gpt-4-0125-preview")
+        self.mad: bool = False
+        self.ant_positions: dict[int, tuple[float, float]] = {}
+        self.fed: int = 0
+        self.move_counter: int = 0
+        self.thought_timer: int = 0
+        self.current_thought: str = ""
+        self.glow_item = None
+        self.glow_state = 0
+        self.expression_item = None
+        if isinstance(sim.canvas, tk.Canvas):
+            self.glow_item = sim.canvas.create_oval(x - 5, y - 10, x + ANT_SIZE + 5, y + ANT_SIZE + 10, outline="yellow", width=2)
+            sim.canvas.tag_lower(self.glow_item, self.item)
+            self.expression_item = sim.canvas.create_text(x + ANT_SIZE / 2, y - 15, text=":)", font=("Arial", 12))
+            self.animate_glow()
+
+    def feed(self, amount: float = 10) -> None:
+        self.hunger = min(100, self.hunger + amount)
+
+    def hunger_color(self) -> str:
+        if self.hunger > 60:
+            return PALETTE["bar_green"]
+        if self.hunger > 30:
+            return PALETTE["bar_yellow"]
+        return PALETTE["bar_red"]
+
+    def update_hunger_bar(self) -> None:
+        x1, y1, x2, _ = self.sim.canvas.coords(self.item)
+        self._set_coords(self.hunger_bar_bg, x1, y1 - 6, x2, y1 - 4)
+        width = (self.hunger / 100) * (x2 - x1)
+        self._set_coords(self.hunger_bar, x1, y1 - 6, x1 + width, y1 - 4)
+        self.sim.canvas.itemconfigure(self.hunger_bar, fill=self.hunger_color())
+
+    def _set_coords(self, item: int, x1: float, y1: float, x2: float, y2: float) -> None:
+        try:
+            self.sim.canvas.coords(item, x1, y1, x2, y2)
+        except TypeError:
+            if hasattr(self.sim.canvas, "objects"):
+                self.sim.canvas.objects[item] = [x1, y1, x2, y2]
+
+    def thought(self) -> str:
+        key = os.getenv("OPENAI_API_KEY")
+        default = [
+            "I demand more food.",
+            "Where are my loyal workers?",
+            "This colony better prosper.",
+            "Another day of ruling...",
+            "Perhaps a nap soon.",
+        ]
+        prompt = {
+            "hunger": int(self.hunger),
+            "fed": self.fed,
+            "food": self.sim.food_collected,
+            "ants": len(getattr(self.sim, "ants", [])),
+            "eggs": len(getattr(self.sim, "eggs", [])),
+        }
+        if self.thought_timer > 0:
+            self.thought_timer -= 1
+            return self.current_thought
+        if not key:
+            new_thought = random.choice(default)
+        else:
+            messages = [
+                {"role": "system", "content": "You are a snarky ant queen. Reply with a single short thought about your state."},
+                {"role": "user", "content": json.dumps(prompt)},
+            ]
+            resp = chat_completion(messages, self.model, 20)
+            new_thought = resp or random.choice(default)
+        self.current_thought = new_thought
+        self.thought_timer = 5
+        return new_thought
+
+    def decide_spawn(self) -> bool:
+        key = os.getenv("OPENAI_API_KEY")
+        counts: dict[str, int] = {}
+        for ant in self.sim.ants:
+            role = getattr(ant, "role", ant.__class__.__name__)
+            counts[role] = counts.get(role, 0) + 1
+        if not key:
+            worker_count = counts.get("WorkerAnt", 0)
+            return self.sim.food_collected > worker_count and self.hunger > 30
+        prompt = {
+            "hunger": self.hunger,
+            "ants": len(self.sim.ants),
+            "food": self.sim.food_collected,
+            "population": counts,
+        }
+        messages = [
+            {"role": "system", "content": "Respond with yes or no if the queen should spawn a new worker."},
+            {"role": "user", "content": json.dumps(prompt)},
+        ]
+        resp = chat_completion(messages, self.model, 1)
+        return resp is None or resp.strip().lower().startswith("y")
+
+    def rescue_stuck_ants(self) -> None:
+        for ant in self.sim.ants:
+            coords = self.sim.canvas.coords(ant.item)
+            last = self.ant_positions.get(ant.item)
+            if last is not None and coords[:2] == list(last):
+                self.sim.canvas.move(
+                    ant.item,
+                    random.choice([-MOVE_STEP, MOVE_STEP]),
+                    random.choice([-MOVE_STEP, MOVE_STEP]),
+                )
+                coords = self.sim.canvas.coords(ant.item)
+            self.ant_positions[ant.item] = (coords[0], coords[1])
+
+    def lay_egg(self, x: int, y: int) -> None:
+        spawn_direct = False
+        if not hasattr(self.sim, "eggs"):
+            self.sim.eggs = []
+            spawn_direct = True
+        egg = Egg(self.sim, x, y)
+        self.sim.eggs.append(egg)
+        if spawn_direct:
+            self.sim.eggs.remove(egg)
+            self.sim.ants.append(WorkerAnt(self.sim, x, y, "blue"))
+
+    def animate_glow(self) -> None:
+        if self.glow_item is None:
+            return
+        self.glow_state = (self.glow_state + 1) % 2
+        width = 1 if self.glow_state == 0 else 3
+        color = "yellow" if self.glow_state == 0 else "orange"
+        self.sim.canvas.itemconfigure(self.glow_item, width=width, outline=color)
+        self.sim.master.after(200, self.animate_glow)
+
+    def update(self) -> None:
+        self.hunger -= 0.1
+        self.spawn_timer -= 1
+        self.move_counter += 1
+        if self.move_counter % 20 == 0:
+            dx = random.choice([-1, 0, 1])
+            dy = random.choice([-1, 0, 1])
+            x1, y1, _, _ = self.sim.canvas.coords(self.item)
+            new_x1 = max(0, min(WINDOW_WIDTH - 40, x1 + dx))
+            new_y1 = max(0, min(WINDOW_HEIGHT - 20, y1 + dy))
+            self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+        if self.hunger < 50:
+            self.sim.canvas.itemconfigure(self.item, fill=PALETTE["bar_red"])
+            self.mad = True
+        else:
+            self.sim.canvas.itemconfigure(self.item, fill=PALETTE["neon_purple"])
+            self.mad = False
+        if self.expression_item is not None:
+            x1, y1, x2, _ = self.sim.canvas.coords(self.item)
+            cx = (x1 + x2) / 2
+            expr = ">:(" if self.mad else (":D" if self.hunger > 80 else ":(" if self.hunger < 40 else ":|")
+            self.sim.canvas.coords(self.expression_item, cx, y1 - 15)
+            self.sim.canvas.itemconfigure(self.expression_item, text=expr)
+        if self.mad:
+            self.rescue_stuck_ants()
+        if self.spawn_timer <= 0 and self.hunger > 0:
+            if self.decide_spawn():
+                x1, y1, x2, _ = self.sim.canvas.coords(self.item)
+                x = (x1 + x2) / 2
+                y = y1 - ANT_SIZE * 2
+                self.lay_egg(int(x), int(y))
+            self.spawn_timer = 300
+        self.update_hunger_bar()

--- a/ant_hive/entities/scout.py
+++ b/ant_hive/entities/scout.py
@@ -1,0 +1,34 @@
+import random
+
+from ..constants import ANT_SIZE, MOVE_STEP, WINDOW_WIDTH, WINDOW_HEIGHT, SCOUT_PHEROMONE_AMOUNT
+from .base_ant import BaseAnt
+
+
+class ScoutAnt(BaseAnt):
+    """Ant that explores randomly, remembering visited positions."""
+
+    def __init__(self, sim: "AntSim", x: int, y: int, color: str = "black") -> None:
+        super().__init__(sim, x, y, color)
+        self.visited: set[tuple[float, float]] = {(float(x), float(y))}
+
+    def update(self) -> None:
+        x1, y1, _, _ = self.sim.canvas.coords(self.item)
+        moves = []
+        for dx in (-MOVE_STEP, 0, MOVE_STEP):
+            for dy in (-MOVE_STEP, 0, MOVE_STEP):
+                if dx == 0 and dy == 0:
+                    continue
+                new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
+                new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
+                if (new_x1, new_y1) not in self.visited:
+                    moves.append((dx, dy, new_x1, new_y1))
+        if moves:
+            dx, dy, new_x1, new_y1 = random.choice(moves)
+            self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+        else:
+            self.move_random()
+        coords = self.sim.canvas.coords(self.item)
+        if hasattr(self.sim, "deposit_pheromone"):
+            self.sim.deposit_pheromone(coords[0], coords[1], SCOUT_PHEROMONE_AMOUNT)
+        self.last_pos = (coords[0], coords[1])
+        self.visited.add(self.last_pos)

--- a/ant_hive/entities/soldier.py
+++ b/ant_hive/entities/soldier.py
@@ -1,0 +1,24 @@
+import random
+
+from ..constants import ANT_SIZE, MOVE_STEP, WINDOW_WIDTH, WINDOW_HEIGHT
+from ..terrain import TILE_SIZE
+from .base_ant import BaseAnt
+
+
+class SoldierAnt(BaseAnt):
+    """Simple soldier ant that patrols around the queen."""
+
+    def update(self) -> None:
+        if self.energy <= 0:
+            self.rest()
+        else:
+            qx1, qy1, qx2, qy2 = self.sim.canvas.coords(self.sim.queen.item)
+            ax1, ay1, _, _ = self.sim.canvas.coords(self.item)
+            cx = (qx1 + qx2) / 2
+            cy = (qy1 + qy2) / 2
+            if abs(ax1 - cx) > TILE_SIZE * 3 or abs(ay1 - cy) > TILE_SIZE * 3:
+                self.move_towards(self.sim.queen.item)
+            else:
+                self.move_random()
+        coords = self.sim.canvas.coords(self.item)
+        self.last_pos = (coords[0], coords[1])

--- a/ant_hive/entities/spider.py
+++ b/ant_hive/entities/spider.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+import random
+
+from ..constants import ANT_SIZE, MOVE_STEP, WINDOW_WIDTH, WINDOW_HEIGHT, PALETTE
+from .base_ant import BaseAnt
+
+
+class SpiderBrain:
+    """Very small neural controller for spider movement."""
+
+    def __init__(self) -> None:
+        self.weights = [[0.5, -0.25, 0.3], [-0.25, 0.5, 0.3]]
+
+    def decide(self, inputs: tuple[float, float, float]) -> tuple[int, int]:
+        raw = []
+        for row in self.weights:
+            val = sum(i * w for i, w in zip(inputs, row))
+            raw.append(val)
+        dx = MOVE_STEP if raw[0] > 0.1 else -MOVE_STEP if raw[0] < -0.1 else 0
+        dy = MOVE_STEP if raw[1] > 0.1 else -MOVE_STEP if raw[1] < -0.1 else 0
+        return dx, dy
+
+
+class Spider:
+    """Predator equipped with a simple neural network brain."""
+
+    def __init__(self, sim: "AntSim", x: int, y: int, energy: int = 50, health: int = 30) -> None:
+        self.sim = sim
+        self.energy = energy
+        self.health = health
+        self.vitality = float(health)
+        self.hunger = 0
+        self.consumed = 0
+        self.brain = SpiderBrain()
+        self.item = sim.canvas.create_oval(x, y, x + ANT_SIZE, y + ANT_SIZE, fill="brown")
+        self.life_bar_bg = sim.canvas.create_rectangle(x, y - 4, x + ANT_SIZE, y - 2, fill=PALETTE["bar_bg"])
+        self.life_bar = sim.canvas.create_rectangle(x, y - 4, x + ANT_SIZE, y - 2, fill=PALETTE["bar_green"])
+        self.hunger_bar_bg = sim.canvas.create_rectangle(x, y + ANT_SIZE + 2, x + ANT_SIZE, y + ANT_SIZE + 4, fill=PALETTE["bar_bg"])
+        self.hunger_bar = sim.canvas.create_rectangle(x, y + ANT_SIZE + 2, x + ANT_SIZE, y + ANT_SIZE + 4, fill=PALETTE["bar_green"])
+
+    def life_color(self) -> str:
+        if self.vitality > 60:
+            return PALETTE["bar_green"]
+        if self.vitality > 30:
+            return PALETTE["bar_yellow"]
+        return PALETTE["bar_red"]
+
+    def hunger_color(self) -> str:
+        if self.hunger < 3:
+            return PALETTE["bar_green"]
+        if self.hunger < 6:
+            return PALETTE["bar_yellow"]
+        return PALETTE["bar_red"]
+
+    def update_bars(self) -> None:
+        x1, y1, x2, y2 = self.sim.canvas.coords(self.item)
+        self.sim.canvas.coords(self.life_bar_bg, x1, y1 - 4, x2, y1 - 2)
+        width = (self.vitality / self.health) * (x2 - x1)
+        self.sim.canvas.coords(self.life_bar, x1, y1 - 4, x1 + width, y1 - 2)
+        self.sim.canvas.itemconfigure(self.life_bar, fill=self.life_color())
+        self.sim.canvas.coords(self.hunger_bar_bg, x1, y2 + 2, x2, y2 + 4)
+        hwidth = min(1.0, self.hunger / 10) * (x2 - x1)
+        self.sim.canvas.coords(self.hunger_bar, x1, y2 + 2, x1 + hwidth, y2 + 4)
+        self.sim.canvas.itemconfigure(self.hunger_bar, fill=self.hunger_color())
+
+    def brain_move(self) -> None:
+        if not self.sim.ants:
+            return
+        x1, y1, x2, y2 = self.sim.canvas.coords(self.item)
+        cx = (x1 + x2) / 2
+        cy = (y1 + y2) / 2
+        ant = min(self.sim.ants, key=lambda a: ((self.sim.canvas.coords(a.item)[0] - cx) ** 2 + (self.sim.canvas.coords(a.item)[1] - cy) ** 2))
+        ax1, ay1, ax2, ay2 = self.sim.canvas.coords(ant.item)
+        ax = (ax1 + ax2) / 2
+        ay = (ay1 + ay2) / 2
+        dx_in = ax - cx
+        dy_in = ay - cy
+        inputs = (dx_in, dy_in, float(self.hunger))
+        dx, dy = self.brain.decide(inputs)
+        new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
+        new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
+        self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+
+    def attack_ants(self) -> None:
+        for ant in self.sim.ants[:]:
+            if self.sim.check_collision(self.item, ant.item):
+                ant.consume_energy(20)
+                if ant.energy <= 0:
+                    self.sim.canvas.delete(ant.item)
+                    if hasattr(ant, "image_id"):
+                        self.sim.canvas.delete(ant.image_id)
+                    self.sim.ants.remove(ant)
+                    self.consumed += 1
+                    if self.consumed % 3 == 0:
+                        self.hunger += 1
+
+    def update(self) -> None:
+        if self.vitality <= 0:
+            if self in self.sim.predators:
+                self.sim.predators.remove(self)
+            for item in (self.item, self.life_bar_bg, self.life_bar, self.hunger_bar_bg, self.hunger_bar):
+                self.sim.canvas.delete(item)
+            return
+        self.vitality -= 0.05
+        self.brain_move()
+        self.attack_ants()
+        self.update_bars()

--- a/ant_hive/entities/worker.py
+++ b/ant_hive/entities/worker.py
@@ -1,0 +1,84 @@
+import random
+
+from ..constants import (
+    ANT_SIZE,
+    ENERGY_MAX,
+    WINDOW_WIDTH,
+    WINDOW_HEIGHT,
+)
+from ..terrain import TILE_SIZE
+from .base_ant import BaseAnt
+from ..terrain import TILE_SIZE, TILE_TUNNEL, TILE_SAND, TILE_ROCK, TILE_COLLAPSED
+
+
+class WorkerAnt(BaseAnt):
+    """Ant focused on collecting food and feeding the queen."""
+
+    def update(self) -> None:
+        if self.energy <= 0:
+            self.rest()
+            coords = self.sim.canvas.coords(self.item)
+            self.last_pos = (coords[0], coords[1])
+            return
+        start = self.sim.canvas.coords(self.item)
+        best_dir = None
+        best_value = -1.0
+        if not self.carrying_food:
+            for drop in getattr(self.sim, "food_drops", []):
+                if self.sim.check_collision(self.item, drop.item):
+                    if drop.take_charge():
+                        self.energy = min(ENERGY_MAX, self.energy + 20)
+                        self.carrying_food = True
+                        cx = start[0] + ANT_SIZE / 2
+                        cy = start[1] + ANT_SIZE / 2
+                        self.sim.sparkle(cx, cy)
+                    if drop.charges <= 0:
+                        self.sim.food_drops.remove(drop)
+                    break
+            if not self.carrying_food:
+                x1, y1, _, _ = self.sim.canvas.coords(self.item)
+                for dx in (-TILE_SIZE, 0, TILE_SIZE):
+                    for dy in (-TILE_SIZE, 0, TILE_SIZE):
+                        if dx == 0 and dy == 0:
+                            continue
+                        nx = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
+                        ny = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
+                        val = self.sim.get_pheromone(nx, ny)
+                        if val > best_value:
+                            best_value = val
+                            best_dir = (nx - x1, ny - y1)
+            if best_value > 0 and best_dir is not None:
+                self.sim.canvas.move(self.item, best_dir[0], best_dir[1])
+                self.sim.canvas.move(self.image_id, best_dir[0], best_dir[1])
+            else:
+                self.move_towards(self.sim.food)
+            if self.sim.check_collision(self.item, self.sim.food):
+                self.carrying_food = True
+                self.sim.food_collected += 1
+                self.sim.move_food()
+                cx = start[0] + ANT_SIZE / 2
+                cy = start[1] + ANT_SIZE / 2
+                self.sim.sparkle(cx, cy)
+        else:
+            self.move_towards(self.sim.queen.item)
+            if self.sim.check_collision(self.item, self.sim.queen.item):
+                self.sim.queen.feed()
+                self.sim.queen.fed += 1
+                self.sim.queen_fed += 1
+                if random.random() < 0.3:
+                    qx1, qy1, _, _ = self.sim.canvas.coords(self.sim.queen.item)
+                    self.sim.queen.lay_egg(int(qx1 + 20), int(qy1))
+                self.carrying_food = False
+                coords = self.sim.canvas.coords(self.item)
+                cx = coords[0] + ANT_SIZE / 2
+                cy = coords[1] + ANT_SIZE / 2
+                self.sim.sparkle(cx, cy)
+        coords = self.sim.canvas.coords(self.item)
+        if coords[:2] != start[:2]:
+            x1 = start[0] + ANT_SIZE / 2
+            y1 = start[1] + ANT_SIZE / 2
+            x2 = coords[0] + ANT_SIZE / 2
+            y2 = coords[1] + ANT_SIZE / 2
+            trail = self.sim.canvas.create_line(x1, y1, x2, y2, fill=self.color)
+            self.sim.canvas.after(300, lambda t=trail: self.sim.canvas.delete(t))
+        self.last_pos = (coords[0], coords[1])

--- a/ant_hive/main.py
+++ b/ant_hive/main.py
@@ -1,7 +1,7 @@
-from ant_hive import *
+import tkinter as tk
+from .sim import AntSim
 
 if __name__ == "__main__":
-    import tkinter as tk
     root = tk.Tk()
     root.title("Ant Hive Simulation v0.1")
     app = AntSim(root)

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -1,0 +1,118 @@
+import random
+import tkinter as tk
+from typing import List
+
+from .constants import WINDOW_WIDTH, WINDOW_HEIGHT, PALETTE, TILE_SIZE, PHEROMONE_DECAY
+from .terrain import Terrain, TILE_ROCK
+from .sprites import create_glowing_icon
+from .entities.base_ant import BaseAnt
+from .entities.worker import WorkerAnt
+from .entities.scout import ScoutAnt
+from .entities.soldier import SoldierAnt
+from .entities.nurse import NurseAnt
+from .entities.queen import Queen
+from .entities.spider import Spider
+from .entities.egg import Egg
+from .entities.food import FoodDrop
+from .utils import brightness_at, stipple_from_brightness
+
+
+class AntSim:
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        self.frame = tk.Frame(master, bg=PALETTE["frame"])
+        self.frame.pack(side="left", padx=5, pady=5)
+        self.canvas = tk.Canvas(self.frame, width=WINDOW_WIDTH, height=WINDOW_HEIGHT, bg=PALETTE["background"], highlightthickness=0)
+        self.canvas.pack()
+        self.start_time = time.time()
+        self.overlay = self.canvas.create_rectangle(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT, fill="#112244", outline="", state="hidden")
+        self.status_icon = self.canvas.create_text(5, 5, text="\u2600\ufe0f", anchor="nw", font=("Arial", 16))
+        self.canvas.tag_raise(self.overlay)
+        self.canvas.tag_raise(self.status_icon)
+        self.sidebar_frame = tk.Frame(master, bg=PALETTE["frame"])
+        self.sidebar_frame.pack(side="right", fill="y")
+        self.food_icon = create_glowing_icon(20)
+        self.spawn_button = tk.Button(self.sidebar_frame, image=self.food_icon, text="Food Drop", compound="top", borderwidth=0)
+        self.spawn_button.pack(side="top")
+        self.stats_label = tk.Label(self.sidebar_frame, bg=PALETTE["frame"], font=("Arial", 10))
+        self.stats_label.pack(side="top")
+        self.spawn_button.bind("<ButtonPress-1>", self.start_place_food)
+        self.canvas.bind("<Button-1>", self.place_food)
+        self.placing_food = False
+        self.food_drops: List[FoodDrop] = []
+        self.eggs: List[Egg] = []
+        self.predators: List[Spider] = []
+        self.grid_width = WINDOW_WIDTH // TILE_SIZE
+        self.grid_height = WINDOW_HEIGHT // TILE_SIZE
+        self.pheromones: list[list[float]] = [[0.0 for _ in range(self.grid_height)] for _ in range(self.grid_width)]
+        self.pheromone_items: list[list[int | None]] = [[None for _ in range(self.grid_height)] for _ in range(self.grid_width)]
+        self.terrain = Terrain(self.grid_width, self.grid_height, self.canvas)
+        for _ in range(30):
+            rx = random.randint(0, self.terrain.width - 1)
+            ry = random.randint(self.terrain.height // 2, self.terrain.height - 1)
+            self.terrain.set_cell(rx, ry, TILE_ROCK)
+        self.food: int = self.canvas.create_rectangle(180, 20, 180 + 8, 20 + 8, fill="green")
+        self.queen: Queen = Queen(self, 180, 570)
+        self.ants: List[BaseAnt] = [
+            WorkerAnt(self, 195, 295, "blue"),
+            WorkerAnt(self, 215, 295, "red"),
+            ScoutAnt(self, 235, 295, "black"),
+            SoldierAnt(self, 255, 295, "orange"),
+            NurseAnt(self, 275, 295, "pink"),
+        ]
+        self.predators.append(Spider(self, 50, 50))
+        self.food_collected: int = 0
+        self.queen_fed: int = 0
+        self.update()
+
+    def start_place_food(self, _event) -> None:
+        self.placing_food = True
+
+    def place_food(self, event) -> None:
+        if not self.placing_food:
+            return
+        self.food_drops.append(FoodDrop(self, event.x, event.y))
+        self.placing_food = False
+
+    def deposit_pheromone(self, x: float, y: float, amount: float) -> None:
+        gx = int(x) // TILE_SIZE
+        gy = int(y) // TILE_SIZE
+        if 0 <= gx < self.grid_width and 0 <= gy < self.grid_height:
+            self.pheromones[gx][gy] += amount
+
+    def get_pheromone(self, x: float, y: float) -> float:
+        gx = int(x) // TILE_SIZE
+        gy = int(y) // TILE_SIZE
+        if 0 <= gx < self.grid_width and 0 <= gy < self.grid_height:
+            return self.pheromones[gx][gy]
+        return 0.0
+
+    def decay_pheromones(self) -> None:
+        for x in range(self.grid_width):
+            for y in range(self.grid_height):
+                if self.pheromones[x][y] > 0:
+                    self.pheromones[x][y] = max(0.0, self.pheromones[x][y] - PHEROMONE_DECAY)
+
+    def get_coords(self, item: int) -> list[float]:
+        return self.canvas.coords(item)
+
+    def check_collision(self, a: int, b: int) -> bool:
+        ax1, ay1, ax2, ay2 = self.get_coords(a)
+        bx1, by1, bx2, by2 = self.get_coords(b)
+        return ax1 < bx2 and ax2 > bx1 and ay1 < by2 and ay2 > by1
+
+    def update(self) -> None:
+        for ant in self.ants:
+            ant.update()
+            ant.update_energy_bar()
+        for predator in self.predators[:]:
+            predator.update()
+        for egg in self.eggs[:]:
+            egg.update()
+        self.queen.update()
+        for drop in self.food_drops[:]:
+            if drop.charges <= 0:
+                self.food_drops.remove(drop)
+        self.decay_pheromones()
+        self.stats_label.configure(text=f"Food Collected: {self.food_collected}")
+        self.master.after(100, self.update)

--- a/ant_hive/sprites.py
+++ b/ant_hive/sprites.py
@@ -1,0 +1,43 @@
+import tkinter as tk
+
+from .constants import ANT_SIZE
+
+
+def _load_sprites() -> list[tk.PhotoImage | None]:
+    try:
+        frames: list[tk.PhotoImage] = []
+        for i in range(2):
+            img = tk.PhotoImage(width=ANT_SIZE, height=ANT_SIZE)
+            body_color = "brown"
+            for x in range(ANT_SIZE):
+                for y in range(ANT_SIZE):
+                    if 2 <= x < ANT_SIZE - 2 and 2 <= y < ANT_SIZE - 2:
+                        img.put(body_color, (x, y))
+            leg_y = ANT_SIZE - 2 + (0 if i == 0 else -1)
+            img.put("black", (1, leg_y))
+            img.put("black", (ANT_SIZE - 2, leg_y))
+            frames.append(img)
+        return frames
+    except Exception:
+        return [None, None]
+
+
+ANT_SPRITES = _load_sprites()
+
+
+def create_glowing_icon(size: int = 16, inner: str = "#ffff99", outer: str = "#ff9900") -> tk.PhotoImage:
+    img = tk.PhotoImage(width=size, height=size)
+    cx = cy = size / 2
+    ir, ig, ib = int(inner[1:3], 16), int(inner[3:5], 16), int(inner[5:7], 16)
+    or_, og, ob = int(outer[1:3], 16), int(outer[3:5], 16), int(outer[5:7], 16)
+    max_d = (size / 2) ** 2
+    for x in range(size):
+        for y in range(size):
+            dx = x + 0.5 - cx
+            dy = y + 0.5 - cy
+            t = min(1.0, (dx * dx + dy * dy) / max_d)
+            r = int(ir + (or_ - ir) * t)
+            g = int(ig + (og - ig) * t)
+            b = int(ib + (ob - ib) * t)
+            img.put(f"#{r:02x}{g:02x}{b:02x}", (x, y))
+    return img

--- a/ant_hive/terrain.py
+++ b/ant_hive/terrain.py
@@ -1,0 +1,133 @@
+import tkinter as tk
+
+TILE_SIZE = 20
+TILE_SAND = "sand"
+TILE_TUNNEL = "tunnel"
+TILE_ROCK = "rock"
+TILE_COLLAPSED = "collapsed"
+
+SAND_TEXTURE = (
+    "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAARklEQVR4nO3QMRHAMBADwctjEPRg",
+    "MgSjEAenyJiArfLVqdninjneZZs9Sdz8SmKSqCRm+wdTGEAlMeiGCbwbdsOD3w3v8Q8txS8qFa7u",
+    "XQAAAABJRU5ErkJggg==",
+)
+TUNNEL_TEXTURE = (
+    "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAARklEQVR4nO3QMRHAMBADwctjEIsg",
+    "NA/DFAenyJiArfLVqdninjneZZs9Sdz8SmKSqCRm+wdTGEAlMeiGCbwbdsOD3w3v8Q8OIi4y+xWE",
+    "tQAAAABJRU5ErkJggg==",
+)
+ROCK_TEXTURE = (
+    "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAQklEQVR4nO3QsRHAQAwCwbNqoHO1",
+    "SQ/+4McNWIQiI9ngnu5+bfNNEpNfSUwSlcRsXzCFAVQSg22YwLfhNvzxt+EcPz04LrP+YyCNAAAA",
+    "AElFTkSuQmCC",
+)
+
+class Terrain:
+    """Simple 2D grid representing the underground."""
+
+    colors = {
+        TILE_SAND: "#c2b280",
+        TILE_TUNNEL: "#806517",
+        TILE_ROCK: "#7f7f7f",
+        TILE_COLLAPSED: "black",
+    }
+
+    texture_data = {
+        TILE_SAND: SAND_TEXTURE,
+        TILE_TUNNEL: TUNNEL_TEXTURE,
+        TILE_ROCK: ROCK_TEXTURE,
+    }
+
+    def __init__(self, width: int, height: int, canvas: tk.Canvas) -> None:
+        self.width = width
+        self.height = height
+        self.canvas = canvas
+        self.images: dict[str, tk.PhotoImage | None] = {}
+        for key, data in self.texture_data.items():
+            try:
+                self.images[key] = tk.PhotoImage(data=data)
+            except Exception:
+                self.images[key] = None
+        self.grid: list[list[str]] = [
+            [TILE_SAND for _ in range(height)] for _ in range(width)
+        ]
+        self.rects: list[list[int]] = [[0] * height for _ in range(width)]
+        self.shades: list[list[int]] = [[0] * height for _ in range(width)]
+        self._render()
+
+    def _render(self) -> None:
+        for x in range(self.width):
+            for y in range(self.height):
+                state = self.grid[x][y]
+                if hasattr(self.canvas, "create_image") and self.images.get(state):
+                    rect = self.canvas.create_image(
+                        x * TILE_SIZE,
+                        y * TILE_SIZE,
+                        anchor="nw",
+                        image=self.images[state],
+                    )
+                else:
+                    rect = self.canvas.create_rectangle(
+                        x * TILE_SIZE,
+                        y * TILE_SIZE,
+                        (x + 1) * TILE_SIZE,
+                        (y + 1) * TILE_SIZE,
+                        fill=self.colors[state],
+                    )
+                self.rects[x][y] = rect
+                self._update_shading(x, y)
+
+    def _update_shading(self, x: int, y: int) -> None:
+        if self.shades[x][y]:
+            if hasattr(self.canvas, "delete"):
+                self.canvas.delete(self.shades[x][y])
+            self.shades[x][y] = 0
+        state = self.grid[x][y]
+        if state != TILE_TUNNEL:
+            return
+        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+            nx, ny = x + dx, y + dy
+            if self.get_cell(nx, ny) != TILE_TUNNEL:
+                self.shades[x][y] = self.canvas.create_rectangle(
+                    x * TILE_SIZE,
+                    y * TILE_SIZE,
+                    (x + 1) * TILE_SIZE,
+                    (y + 1) * TILE_SIZE,
+                    fill="#000000",
+                    stipple="gray50",
+                    outline="",
+                )
+                break
+
+    def get_cell(self, x: int, y: int) -> str:
+        if x < 0 or y < 0 or x >= self.width or y >= self.height:
+            return TILE_ROCK
+        return self.grid[x][y]
+
+    def set_cell(self, x: int, y: int, state: str) -> None:
+        if 0 <= x < self.width and 0 <= y < self.height:
+            self.grid[x][y] = state
+            if hasattr(self.canvas, "delete"):
+                self.canvas.delete(self.rects[x][y])
+                if self.shades[x][y]:
+                    self.canvas.delete(self.shades[x][y])
+            if hasattr(self.canvas, "create_image") and self.images.get(state):
+                self.rects[x][y] = self.canvas.create_image(
+                    x * TILE_SIZE,
+                    y * TILE_SIZE,
+                    anchor="nw",
+                    image=self.images[state],
+                )
+            else:
+                self.rects[x][y] = self.canvas.create_rectangle(
+                    x * TILE_SIZE,
+                    y * TILE_SIZE,
+                    (x + 1) * TILE_SIZE,
+                    (y + 1) * TILE_SIZE,
+                    fill=self.colors[state],
+                )
+            self._update_shading(x, y)
+            for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < self.width and 0 <= ny < self.height:
+                    self._update_shading(nx, ny)

--- a/ant_hive/utils.py
+++ b/ant_hive/utils.py
@@ -1,0 +1,34 @@
+import time
+
+
+def lerp(a: float, b: float, t: float) -> float:
+    return a + (b - a) * max(0.0, min(1.0, t))
+
+
+def brightness_at(t: float) -> float:
+    cycle = t % 60.0
+    phase = 30.0
+    trans = 3.0
+    if cycle < phase:
+        if cycle < trans:
+            return lerp(0.5, 1.0, cycle / trans)
+        if cycle > phase - trans:
+            return lerp(1.0, 0.5, (cycle - (phase - trans)) / trans)
+        return 1.0
+    cycle -= phase
+    if cycle < trans:
+        return lerp(1.0, 0.5, cycle / trans)
+    if cycle > phase - trans:
+        return lerp(0.5, 1.0, (cycle - (phase - trans)) / trans)
+    return 0.5
+
+
+def stipple_from_brightness(val: float) -> str:
+    alpha = (1.0 - val) / 0.5
+    if alpha > 0.75:
+        return "gray75"
+    if alpha > 0.5:
+        return "gray50"
+    if alpha > 0.25:
+        return "gray25"
+    return "gray12"


### PR DESCRIPTION
## Summary
- split monolithic `ant_sim.py` into a new `ant_hive` package
- move constants and utilities to dedicated modules
- implement entities in separate files (ants, queen, spider, etc.)
- expose entry point via `ant_hive/main.py`
- keep compatibility by re-exporting from `ant_sim.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f3ddad0c832e954674bb6cd39ef9