### PR TITLE
Display more colony stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ python ant_sim.py
 The sidebar on the right lists each ant's status and overall colony metrics.
 At the top of the sidebar you'll find a **Food Drop** button. Clicking it lets
 you place additional food sources in the simulation. Just below the button a
-small statistics label continuously updates with collected food, queen hunger
-and the number of active ants.
+small statistics label continuously updates with collected food, how much has
+been fed to the queen, the number of active ants, the current egg count and
+how many predators are present.
 
 ## Development
 

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -116,5 +116,12 @@ class AntSim:
             if drop.charges <= 0:
                 self.food_drops.remove(drop)
         self.decay_pheromones()
-        self.stats_label.configure(text=f"Food Collected: {self.food_collected}")
+        stats = (
+            f"Food Collected: {self.food_collected}\n"
+            f"Fed to Queen: {self.queen_fed}\n"
+            f"Ants Active: {len(self.ants)}\n"
+            f"Eggs: {len(self.eggs)}\n"
+            f"Predators: {len(self.predators)}"
+        )
+        self.stats_label.configure(text=stats)
         self.master.after(100, self.update)

--- a/blueprint_ui.py
+++ b/blueprint_ui.py
@@ -66,7 +66,8 @@ class AntHiveUI(tk.Tk):
             "Food Collected: 1\n"
             "Fed to Queen: 0\n"
             "Ants Active: 5\n"
-            "Eggs: 0"
+            "Eggs: 0\n"
+            "Predators: 1"
         )
         tk.Label(top, text=stats_text, bg="#f7e6cb", anchor="w", justify="left").pack(fill="x")
         # Middle section


### PR DESCRIPTION
## Summary
- show extra stats in blueprint UI
- add predators to side bar text
- update README about the new stats

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68670392de58832e8e766b377713e542