### PR TITLE
Fix slowdown from queen's update delay

### DIFF
--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -196,8 +196,11 @@ class Queen:
         self.sim.master.after(200, self.animate_glow)
 
     def update(self) -> None:
+        # Avoid blocking the Tkinter event loop with a long sleep.
+        # The previous implementation paused for four seconds,
+        # freezing the UI each update cycle.
         if isinstance(self.sim.canvas, tk.Canvas):
-            time.sleep(4)
+            time.sleep(0)
         self.hunger -= 0.1
         self.spawn_timer -= 1
         self.move_counter += 1


### PR DESCRIPTION
## Summary
- tweak queen update timing to avoid blocking the Tkinter loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867113c3ba0832e8b304c534976a3af