### PR TITLE
Implement day-night cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ small statistics label continuously updates with collected food, how much has
 been fed to the queen, the number of active ants, the current egg count and
 how many predators are present.
 
+### Day-Night Cycle
+
+The world slowly transitions between day and night over a 60‑second cycle.
+A small icon in the top-left corner shows the sun or moon along with the
+current day number. Nighttime applies a subtle blue tint without hiding the
+scene so the ants remain fully visible. The simulation tracks the day count
+via `AntSim.current_day`, which increments every 60 seconds.
+
 ## Development
 
 The `tests` folder contains a small test suite. Run it with:

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -49,8 +49,13 @@ class AntSim:
             outline="",
             state="hidden",
         )
+        self.current_day = 1
         self.status_icon = self.canvas.create_text(
-            5, 5, text="\u2600\ufe0f", anchor="nw", font=("Arial", 16)
+            5,
+            5,
+            text="\u2600\ufe0f Day 1",
+            anchor="nw",
+            font=("Arial", 16),
         )
         self.canvas.tag_raise(self.overlay)
         self.canvas.tag_raise(self.status_icon)
@@ -98,12 +103,14 @@ class AntSim:
 
         self.ant_list.bind(
             "<Configure>",
-            lambda e: self.ant_canvas.configure(scrollregion=self.ant_canvas.bbox("all"))
+            lambda e: self.ant_canvas.configure(
+                scrollregion=self.ant_canvas.bbox("all")
+            ),
         )
 
         self.ant_canvas.bind(
             "<Configure>",
-            lambda e: self.ant_canvas.itemconfigure(self.ant_window, width=e.width)
+            lambda e: self.ant_canvas.itemconfigure(self.ant_window, width=e.width),
         )
 
         # Panel for overall colony statistics
@@ -160,11 +167,31 @@ class AntSim:
         self.ant_labels: dict[int, tk.Label] = {}
         self.update()
 
+    def update_lighting(self) -> None:
+        """Update overlay brightness and day/night icon."""
+        t = time.time() - self.start_time
+        brightness = brightness_at(t)
+
+        if brightness >= 0.999:
+            # Daytime without overlay
+            self.canvas.itemconfigure(self.overlay, state="hidden")
+        else:
+            self.canvas.itemconfigure(
+                self.overlay,
+                state="normal",
+                stipple=stipple_from_brightness(brightness),
+            )
+
+        cycle = t % 60.0
+        icon = "\u2600\ufe0f" if cycle < 30.0 else "\U0001f319"
+        self.current_day = int(t // 60.0) + 1
+        self.canvas.itemconfigure(self.status_icon, text=f"{icon} Day {self.current_day}")
+
     def refresh_ant_stats(self) -> None:
         active_ids = set()
         for ant in self.ants:
             active_ids.add(ant.ant_id)
-            text = f"\u25A0 ID {ant.ant_id:04d} | {ant.role} | E:{int(ant.energy)} | {ant.status}"
+            text = f"\u25a0 ID {ant.ant_id:04d} | {ant.role} | E:{int(ant.energy)} | {ant.status}"
             label = self.ant_labels.get(ant.ant_id)
             if label is None:
                 label = tk.Label(
@@ -194,7 +221,6 @@ class AntSim:
             f"Queen Thought: {self.queen.thought()}"
         )
         self.colony_stats_label.configure(text=stats)
-
 
     def start_place_food(self, _event) -> None:
         self.placing_food = True
@@ -235,6 +261,7 @@ class AntSim:
         return ax1 < bx2 and ax2 > bx1 and ay1 < by2 and ay2 > by1
 
     def update(self) -> None:
+        self.update_lighting()
         for ant in self.ants:
             ant.update()
             ant.update_energy_bar()

--- a/ant_hive/utils.py
+++ b/ant_hive/utils.py
@@ -6,19 +6,34 @@ def lerp(a: float, b: float, t: float) -> float:
 
 
 def brightness_at(t: float) -> float:
+    """Return lighting brightness for the day\-night cycle.
+
+    The cycle lasts 60 seconds with 30 seconds of day and 30 seconds of night.
+    A short transition of two seconds is applied at the edges using linear
+    interpolation so the lighting changes smoothly.
+    """
+
     cycle = t % 60.0
     phase = 30.0
-    trans = 3.0
+    trans = 2.0
+
     if cycle < phase:
+        # Day time
         if cycle < trans:
+            # Night \-> day transition
             return lerp(0.5, 1.0, cycle / trans)
         if cycle > phase - trans:
+            # Day \-> night transition
             return lerp(1.0, 0.5, (cycle - (phase - trans)) / trans)
         return 1.0
+
     cycle -= phase
+    # Night time
     if cycle < trans:
+        # Day \-> night transition
         return lerp(1.0, 0.5, cycle / trans)
     if cycle > phase - trans:
+        # Night \-> day transition
         return lerp(0.5, 1.0, (cycle - (phase - trans)) / trans)
     return 0.5
 


### PR DESCRIPTION
## Summary
- implement smooth day-night cycle with sun/moon icon
- add day counter to the overlay
- expose `AntSim.current_day` property in docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867180a9d64832ea4d714e0284fb9b7