### PR TITLE
Hide spider during daytime

### DIFF
--- a/ant_hive/entities/spider.py
+++ b/ant_hive/entities/spider.py
@@ -37,6 +37,20 @@ class Spider:
         self.life_bar = sim.canvas.create_rectangle(x, y - 4, x + ANT_SIZE, y - 2, fill=PALETTE["bar_green"])
         self.hunger_bar_bg = sim.canvas.create_rectangle(x, y + ANT_SIZE + 2, x + ANT_SIZE, y + ANT_SIZE + 4, fill=PALETTE["bar_bg"])
         self.hunger_bar = sim.canvas.create_rectangle(x, y + ANT_SIZE + 2, x + ANT_SIZE, y + ANT_SIZE + 4, fill=PALETTE["bar_green"])
+        self.visible = True
+
+    def set_visible(self, visible: bool) -> None:
+        """Show or hide the spider and its UI elements."""
+        state = "normal" if visible else "hidden"
+        for item in (
+            self.item,
+            self.life_bar_bg,
+            self.life_bar,
+            self.hunger_bar_bg,
+            self.hunger_bar,
+        ):
+            self.sim.canvas.itemconfigure(item, state=state)
+        self.visible = visible
 
     def life_color(self) -> str:
         if self.vitality > 60:

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -176,12 +176,16 @@ class AntSim:
         if brightness >= 0.999:
             # Daytime without overlay
             self.canvas.itemconfigure(self.overlay, state="hidden")
+            for predator in self.predators:
+                predator.set_visible(False)
         else:
             self.canvas.itemconfigure(
                 self.overlay,
                 state="normal",
                 stipple=stipple_from_brightness(brightness),
             )
+            for predator in self.predators:
+                predator.set_visible(True)
 
         cycle = t % 60.0
         icon = "\u2600\ufe0f" if cycle < 30.0 else "\U0001f319"


### PR DESCRIPTION
## Summary
- add visibility toggle for predators
- hide predators when it's day

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672523bbc4832eaa2d293604c2d307