### PR TITLE
Make predators nocturnal

### DIFF
--- a/ant_hive/entities/spider.py
+++ b/ant_hive/entities/spider.py
@@ -102,6 +102,7 @@ class Spider:
                 self.sim.canvas.delete(item)
             return
         self.vitality -= 0.05
-        self.brain_move()
-        self.attack_ants()
+        if getattr(self.sim, "is_night", True):
+            self.brain_move()
+            self.attack_ants()
         self.update_bars()

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -41,6 +41,7 @@ class AntSim:
         )
         self.canvas.pack()
         self.start_time = time.time()
+        self.is_night = False
         self.overlay = self.canvas.create_rectangle(
             0,
             0,
@@ -184,6 +185,7 @@ class AntSim:
             )
 
         cycle = t % 60.0
+        self.is_night = cycle >= 30.0
         icon = "\u2600\ufe0f" if cycle < 30.0 else "\U0001f319"
         self.current_day = int(t // 60.0) + 1
         self.canvas.itemconfigure(self.status_icon, text=f"{icon} Day {self.current_day}")

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -43,7 +43,9 @@ class FakeCanvas:
         x1, y1, x2, y2 = self.objects[item_id]
         self.objects[item_id] = [x1 + dx, y1 + dy, x2 + dx, y2 + dy]
 
-    def coords(self, item_id):
+    def coords(self, item_id, *args):
+        if args:
+            self.objects[item_id] = list(args)
         return self.objects[item_id]
 
     def itemconfigure(self, item_id, **kwargs):
@@ -55,6 +57,7 @@ class FakeSim:
         self.canvas = FakeCanvas()
         self.ants = []
         self.predators = []
+        self.is_night = True
 
     def get_coords(self, item):
         return self.canvas.coords(item)
@@ -84,3 +87,15 @@ def test_spider_hunger_increases_after_three_ants():
         sim.ants.append(ant)
     spider.attack_ants()
     assert spider.hunger == 1
+
+
+def test_spider_update_skips_during_day():
+    sim = FakeSim()
+    sim.is_night = False
+    spider = Spider(sim, 0, 0)
+    ant = BaseAnt(sim, 0, 0)
+    sim.ants.append(ant)
+    start_coords = sim.canvas.coords(spider.item)
+    spider.update()
+    assert sim.canvas.coords(spider.item) == start_coords
+    assert ant.energy == 100


### PR DESCRIPTION
## Summary
- track night/day cycle with `AntSim.is_night`
- skip spider movement and attacks during the day
- extend spider tests for daytime behavior

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672515571c832ea916247f0d631fa8