### PR TITLE
Implement random role distribution for hatched ants

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ A small icon in the top-left corner shows the sun or moon along with the
 current day number. Nighttime applies a subtle blue tint without hiding the
 <scene so the ants remain fully visible. The simulation tracks the day count via `AntSim.current_day`, which increments every 60 seconds.
 
+### Egg Hatching
+
+When the queen lays an egg it will hatch into a random ant type. The
+distribution is weighted so that 50% of eggs become workers, 20% scouts,
+20% soldiers and 10% nurses.
+
 ## Development
 
 The `tests` folder contains a small test suite. Run it with:

--- a/ant_hive/entities/egg.py
+++ b/ant_hive/entities/egg.py
@@ -1,9 +1,26 @@
+import random
+
 from ..constants import ANT_SIZE
 from .worker import WorkerAnt
+from .scout import ScoutAnt
+from .soldier import SoldierAnt
+from .nurse import NurseAnt
+
+
+def hatch_random_ant(sim: "AntSim", x: int, y: int):
+    """Return a new ant instance using weighted role probabilities."""
+    r = random.random()
+    if r < 0.5:
+        return WorkerAnt(sim, x, y, "blue")
+    if r < 0.7:
+        return ScoutAnt(sim, x, y, "black")
+    if r < 0.9:
+        return SoldierAnt(sim, x, y, "orange")
+    return NurseAnt(sim, x, y, "pink")
 
 
 class Egg:
-    """Represents an egg that will hatch into a new worker ant."""
+    """Represents an egg that hatches into a random ant role."""
 
     def __init__(self, sim: "AntSim", x: int, y: int, hatch_time: int = 200) -> None:
         self.sim = sim
@@ -16,4 +33,5 @@ class Egg:
             x1, y1, _, _ = self.sim.canvas.coords(self.item)
             self.sim.canvas.delete(self.item)
             self.sim.eggs.remove(self)
-            self.sim.ants.append(WorkerAnt(self.sim, int(x1), int(y1), "blue"))
+            ant = hatch_random_ant(self.sim, int(x1), int(y1))
+            self.sim.ants.append(ant)

--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -6,7 +6,7 @@ import tkinter as tk
 
 from ..constants import ANT_SIZE, WINDOW_WIDTH, WINDOW_HEIGHT, PALETTE, MOVE_STEP
 from ..ai_interface import chat_completion
-from .egg import Egg
+from .egg import Egg, hatch_random_ant
 from .worker import WorkerAnt
 from .base_ant import BaseAnt
 
@@ -183,7 +183,7 @@ class Queen:
         self.sim.eggs.append(egg)
         if spawn_direct:
             self.sim.eggs.remove(egg)
-            self.sim.ants.append(WorkerAnt(self.sim, x, y, "blue"))
+            self.sim.ants.append(hatch_random_ant(self.sim, x, y))
 
     def command_hive(
         self, message: str, role: str | None = None, radius: int | None = None


### PR DESCRIPTION
## Summary
- hatch eggs into randomized ant roles with weighted chances
- allow immediate egg spawning to use the same role distribution
- document egg hatching probabilities in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672538ded4832e9fc4437d9754fc60