### PR TITLE
Extract egg hatching logic into queen.hatch_ant()

### DIFF
--- a/ant_hive/entities/egg.py
+++ b/ant_hive/entities/egg.py
@@ -1,5 +1,4 @@
 from ..constants import ANT_SIZE
-from .worker import WorkerAnt
 
 
 class Egg:
@@ -16,4 +15,5 @@ class Egg:
             x1, y1, _, _ = self.sim.canvas.coords(self.item)
             self.sim.canvas.delete(self.item)
             self.sim.eggs.remove(self)
-            self.sim.ants.append(WorkerAnt(self.sim, int(x1), int(y1), "blue"))
+            # Delegate role selection and spawning to the queen
+            self.sim.queen.hatch_ant(int(x1), int(y1))

--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -183,7 +183,15 @@ class Queen:
         self.sim.eggs.append(egg)
         if spawn_direct:
             self.sim.eggs.remove(egg)
-            self.sim.ants.append(WorkerAnt(self.sim, x, y, "blue"))
+            self.hatch_ant(x, y)
+
+    def hatch_ant(self, x: int, y: int) -> None:
+        """Hatch a new ant at the given position.
+
+        Role selection occurs here so the logic can be tweaked in
+        one place. For now this simply spawns a worker ant.
+        """
+        self.sim.ants.append(WorkerAnt(self.sim, x, y, "blue"))
 
     def command_hive(
         self, message: str, role: str | None = None, radius: int | None = None

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -117,6 +117,22 @@ def test_queen_spawns_new_worker():
     FakeSim()
     # This placeholder test simply ensures construction succeeds
 
+def test_egg_hatch_calls_hatch_ant():
+    sim = FakeSim()
+    sim.eggs = []
+    called = []
+
+    def fake_hatch(x, y):
+        called.append((x, y))
+
+    sim.queen.hatch_ant = fake_hatch
+    sim.queen.lay_egg(5, 5)
+    egg = sim.eggs[0]
+    egg.hatch_time = 1
+    egg.update()
+
+    assert called == [(5, 5)]
+
 @patch("ant_sim.openai.ChatCompletion.create")
 def test_ai_base_ant_moves_with_openai(mock_create):
     os.environ["OPENAI_API_KEY"] = "test"


### PR DESCRIPTION
## Summary
- centralize hatching logic in `Queen.hatch_ant`
- delegate egg hatching to the queen
- test that eggs call the new hatch method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672546db14832ea94cb860657bc620