### PR TITLE
Fix egg hatch bug and spawn in tests

### DIFF
--- a/ant_hive/entities/egg.py
+++ b/ant_hive/entities/egg.py
@@ -6,6 +6,7 @@ from .scout import ScoutAnt
 from .soldier import SoldierAnt
 from .nurse import NurseAnt
 
+
 def hatch_random_ant(sim: "AntSim", x: int, y: int):
     """Return a new ant instance using weighted role probabilities."""
     r = random.random()
@@ -18,14 +19,15 @@ def hatch_random_ant(sim: "AntSim", x: int, y: int):
     return NurseAnt(sim, x, y, "pink")
 
 
-
 class Egg:
     """Represents an egg that hatches into a random ant role."""
 
     def __init__(self, sim: "AntSim", x: int, y: int, hatch_time: int = 200) -> None:
         self.sim = sim
         self.hatch_time = hatch_time
-        self.item = sim.canvas.create_oval(x, y, x + ANT_SIZE, y + ANT_SIZE, fill="white")
+        self.item = sim.canvas.create_oval(
+            x, y, x + ANT_SIZE, y + ANT_SIZE, fill="white"
+        )
 
     def update(self) -> None:
         self.hatch_time -= 1
@@ -33,6 +35,5 @@ class Egg:
             x1, y1, _, _ = self.sim.canvas.coords(self.item)
             self.sim.canvas.delete(self.item)
             self.sim.eggs.remove(self)
-        # Delegate role selection and spawning to the queen
-        self.sim.queen.hatch_ant(int(x1), int(y1))
-
+            # Delegate role selection and spawning to the queen
+            self.sim.queen.hatch_ant(int(x1), int(y1))

--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -183,10 +183,14 @@ class Queen:
         self.sim.eggs.append(egg)
         if spawn_direct:
             self.sim.eggs.remove(egg)
+            # In minimal test environments without an egg list,
+            # spawn the ant immediately so behavior matches the full
+            # simulation where eggs eventually hatch.
+            self.hatch_ant(x, y)
+
     def hatch_ant(self, x: int, y: int) -> None:
         """Hatch a new ant at the given position using weighted role probabilities."""
         self.sim.ants.append(hatch_random_ant(self.sim, x, y))
-
 
     def command_hive(
         self, message: str, role: str | None = None, radius: int | None = None


### PR DESCRIPTION
## Summary
- ensure egg hatch coordinates are only referenced after hatching
- spawn ants immediately when no egg list exists (used by tests)

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672b420fd0832eb3f8aefe86a93be2