### PR TITLE
Make OpenAI calls asynchronous

### DIFF
--- a/ant_hive/ai_interface.py
+++ b/ant_hive/ai_interface.py
@@ -1,5 +1,7 @@
 import os
 import concurrent.futures
+import asyncio
+import threading
 
 try:
     import openai
@@ -20,13 +22,29 @@ openai.api_key = os.getenv("OPENAI_API_KEY", "")
 
 _executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
 
+# Event loop running in a background thread for async tasks
+_loop = asyncio.new_event_loop()
 
-def _chat_task(messages: list[dict], model: str, max_tokens: int) -> str | None:
+def _run_loop() -> None:  # pragma: no cover - thread bootstrap
+    asyncio.set_event_loop(_loop)
+    _loop.run_forever()
+
+_thread = threading.Thread(target=_run_loop, daemon=True)
+_thread.start()
+
+
+async def _chat_task_async(
+    messages: list[dict], model: str, max_tokens: int
+) -> str | None:
+    loop = asyncio.get_running_loop()
     try:
-        resp = openai.ChatCompletion.create(
-            model=model,
-            messages=messages,
-            max_tokens=max_tokens,
+        resp = await loop.run_in_executor(
+            _executor,
+            lambda: openai.ChatCompletion.create(
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+            ),
         )
         return resp.choices[0].message["content"].strip()
     except Exception:
@@ -37,4 +55,15 @@ def chat_completion(
     messages: list[dict], model: str, max_tokens: int = 20
 ) -> concurrent.futures.Future:
     """Return a future that resolves with the completion text."""
-    return _executor.submit(_chat_task, messages, model, max_tokens)
+
+    future: concurrent.futures.Future = concurrent.futures.Future()
+
+    async def runner() -> None:
+        result = await _chat_task_async(messages, model, max_tokens)
+        future.set_result(result)
+
+    def schedule() -> None:  # pragma: no cover - thread handoff
+        asyncio.create_task(runner())
+
+    _loop.call_soon_threadsafe(schedule)
+    return future


### PR DESCRIPTION
## Summary
- start a background asyncio loop in `ai_interface`
- run OpenAI completions via `asyncio.create_task` so they no longer block the main loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867255f7d38832e8feb0e01d6e9a7d0