### PR TITLE
Add queen thinking indicator

### DIFF
--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -39,6 +39,7 @@ class Queen:
         self.glow_item = None
         self.glow_state = 0
         self.expression_item = None
+        self.thinking_item = None
         self._thought_future = None
         self._spawn_future = None
         if isinstance(sim.canvas, tk.Canvas):
@@ -53,6 +54,14 @@ class Queen:
             sim.canvas.tag_lower(self.glow_item, self.item)
             self.expression_item = sim.canvas.create_text(
                 x + ANT_SIZE / 2, y - 15, text=":)", font=("Arial", 12)
+            )
+            self.thinking_item = sim.canvas.create_text(
+                x + ANT_SIZE / 2,
+                y - 30,
+                text="Thinking...",
+                font=("Arial", 10, "italic"),
+                fill="white",
+                state="hidden",
             )
             self.animate_glow()
 
@@ -211,6 +220,22 @@ class Queen:
         self.sim.canvas.itemconfigure(self.glow_item, width=width, outline=color)
         self.sim.master.after(200, self.animate_glow)
 
+    def update_thinking_indicator(self) -> None:
+        if self.thinking_item is None:
+            return
+        waiting = False
+        if self._thought_future is not None and not self._thought_future.done():
+            waiting = True
+        if self._spawn_future is not None and not self._spawn_future.done():
+            waiting = True
+        if waiting:
+            x1, y1, x2, _ = self.sim.canvas.coords(self.item)
+            cx = (x1 + x2) / 2
+            self.sim.canvas.coords(self.thinking_item, cx, y1 - 30)
+            self.sim.canvas.itemconfigure(self.thinking_item, state="normal")
+        else:
+            self.sim.canvas.itemconfigure(self.thinking_item, state="hidden")
+
     def update(self) -> None:
         # Avoid blocking the Tkinter event loop with a long sleep.
         # The previous implementation paused for four seconds,
@@ -264,3 +289,4 @@ class Queen:
                 self.command_hive("Soldiers: defend colony.", role="SoldierAnt")
                 self.command_cooldown = 50
         self.update_hunger_bar()
+        self.update_thinking_indicator()


### PR DESCRIPTION
## Summary
- show a "Thinking..." text above the queen while waiting on AI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672577246c832ea5e5e233273bd26e