### PR TITLE
Fix stray text in spider module

### DIFF
--- a/ant_hive/entities/spider.py
+++ b/ant_hive/entities/spider.py
@@ -83,7 +83,6 @@ class Spider:
         ):
             self.sim.canvas.itemconfigure(item, state=state)
         self.visible = visible
-   main
 
     def life_color(self) -> str:
         if self.vitality > 60:
@@ -227,4 +226,3 @@ class Spider:
         self.size *= 1.20
         self.speed = BASE_SPEED * self.size
         self.food_consumption = BASE_CONSUMPTION * self.size
-      main


### PR DESCRIPTION
## Summary
- remove accidental `main` strings in spider entity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673b62edb8832e972d6b0a8fdb94f1