### PR TITLE
Underground spawn and predator limits

### DIFF
--- a/ant_hive/entities/spider.py
+++ b/ant_hive/entities/spider.py
@@ -8,6 +8,7 @@ from ..constants import (
     WINDOW_HEIGHT,
     PALETTE,
 )
+from ..terrain import TILE_SIZE, TILE_TUNNEL
 from ..utils import brightness_at
 from .base_ant import BaseAnt
 
@@ -73,6 +74,22 @@ class Spider:
         self.has_laid_eggs = False
         self.alive = True
         self.last_is_night = True
+
+    def _terrain_blocked(self, x: float, y: float) -> bool:
+        if hasattr(self.sim, "terrain"):
+            tx = int((x + ANT_SIZE / 2) // TILE_SIZE)
+            ty = int((y + ANT_SIZE / 2) // TILE_SIZE)
+            if self.sim.terrain.get_cell(tx, ty) == TILE_TUNNEL:
+                return True
+        return False
+
+    def attempt_move(self, dx: float, dy: float) -> None:
+        x1, y1, _, _ = self.sim.canvas.coords(self.item)
+        new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
+        new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
+        if self._terrain_blocked(new_x1, new_y1):
+            return
+        self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
 
     def set_visible(self, visible: bool) -> None:
         """Show or hide the spider and its UI elements."""
@@ -163,9 +180,7 @@ class Spider:
         scale = self.speed / MOVE_STEP
         dx *= scale
         dy *= scale
-        new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
-        new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
-        self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+        self.attempt_move(dx, dy)
 
 
     def _distance_to(self, ant: BaseAnt) -> float:
@@ -254,9 +269,7 @@ class Spider:
         scale = self.speed / MOVE_STEP
         dx *= scale
         dy *= scale
-        new_x1 = max(0, min(WINDOW_WIDTH - ANT_SIZE, x1 + dx))
-        new_y1 = max(0, min(WINDOW_HEIGHT - ANT_SIZE, y1 + dy))
-        self.sim.canvas.move(self.item, new_x1 - x1, new_y1 - y1)
+        self.attempt_move(dx, dy)
 
     def sleep_cycle(self) -> None:
         self.grow()

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -13,7 +13,7 @@ from .constants import (
     MONO_FONT,
     FOOD_SIZE,
 )
-from .terrain import Terrain, TILE_ROCK
+from .terrain import Terrain, TILE_ROCK, TILE_TUNNEL
 from .sprites import create_glowing_icon
 from .entities.base_ant import BaseAnt
 from .entities.worker import WorkerAnt
@@ -153,7 +153,14 @@ class AntSim:
             ry = random.randint(self.terrain.height // 2, self.terrain.height - 1)
             self.terrain.set_cell(rx, ry, TILE_ROCK)
         center_x = (self.grid_width // 2) * TILE_SIZE
-        center_y = (self.grid_height // 3) * TILE_SIZE
+        center_y = (self.grid_height * 2 // 3) * TILE_SIZE
+        for dx in range(-2, 3):
+            for dy in range(-2, 3):
+                self.terrain.set_cell(
+                    self.grid_width // 2 + dx,
+                    self.grid_height * 2 // 3 + dy,
+                    TILE_TUNNEL,
+                )
         self.food: int | None = None
         self.queen: Queen = Queen(self, center_x, center_y)
         self.ants: List[BaseAnt] = [
@@ -163,7 +170,7 @@ class AntSim:
             SoldierAnt(self, center_x + 75, center_y + 5, "orange"),
             NurseAnt(self, center_x + 95, center_y + 5, "pink"),
         ]
-        self.predators.append(Spider(self, 50, 50))
+        self.predators.append(Spider(self, 50, TILE_SIZE * 2))
         self.food_collected: int = 0
         self.queen_fed: int = 0
         self.ant_labels: dict[int, tk.Label] = {}


### PR DESCRIPTION
## Summary
- spawn queen and ants in an underground chamber
- create a small starting tunnel network
- place spiders near the surface
- restrict spiders from entering tunnel tiles

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676bf155a8832eb5cde97b2396e3e1