### PR TITLE
Update worker ants to use user food drops more effectively

### DIFF
--- a/ant_hive/entities/worker.py
+++ b/ant_hive/entities/worker.py
@@ -47,16 +47,23 @@ class WorkerAnt(BaseAnt):
             nearest_dist = float("inf")
             for drop in getattr(self.sim, "food_drops", []):
                 if self.sim.check_collision(self.item, drop.item):
-                    if drop.take_charge():
-                        self.energy = min(ENERGY_MAX, self.energy + 20)
-                        self.carrying_food = True
-                        self.sim.food_collected += 1
-                        cx = start[0] + ANT_SIZE / 2
-                        cy = start[1] + ANT_SIZE / 2
-                        self.sim.sparkle(cx, cy)
+                    took = False
+                    while self.energy < ENERGY_MAX and drop.charges > 0:
+                        if drop.take_charge():
+                            took = True
+                            self.energy = min(ENERGY_MAX, self.energy + 20)
+                    if drop.charges > 0 and not self.carrying_food:
+                        if drop.take_charge():
+                            took = True
+                            self.carrying_food = True
+                            self.sim.food_collected += 1
+                            cx = start[0] + ANT_SIZE / 2
+                            cy = start[1] + ANT_SIZE / 2
+                            self.sim.sparkle(cx, cy)
                     if drop.charges <= 0:
                         self.sim.food_drops.remove(drop)
-                    break
+                    if took:
+                        break
                 else:
                     dx = self.sim.canvas.coords(drop.item)[0] - start[0]
                     dy = self.sim.canvas.coords(drop.item)[1] - start[1]


### PR DESCRIPTION
## Summary
- worker ants now fully replenish themselves from food drops before taking an extra charge to deliver to the queen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676ee07ff0832e91d01435b9e5e1e2