### PR TITLE
Add tile-based visibility for ants and queen

### DIFF
--- a/ant_hive/entities/base_ant.py
+++ b/ant_hive/entities/base_ant.py
@@ -157,6 +157,28 @@ class BaseAnt:
             if hasattr(self.sim.canvas, "objects"):
                 self.sim.canvas.objects[item] = [x1, y1, x2, y2]
 
+    def update_visibility(self) -> None:
+        """Hide or show the ant based on the terrain cell under it."""
+        if not self.terrain:
+            return
+        x1, y1, x2, y2 = self.sim.canvas.coords(self.item)
+        cx = (x1 + x2) / 2
+        cy = (y1 + y2) / 2
+        tx = int(cx // TILE_SIZE)
+        ty = int(cy // TILE_SIZE)
+        visible = self.terrain.get_cell(tx, ty) == TILE_TUNNEL
+        state = "normal" if visible else "hidden"
+        for item in (
+            self.item,
+            self.image_id,
+            self.energy_bar_bg,
+            self.energy_bar,
+        ):
+            try:
+                self.sim.canvas.itemconfigure(item, state=state)
+            except Exception:
+                pass
+
     def update(self) -> None:
         if not self.alive:
             return
@@ -176,6 +198,7 @@ class BaseAnt:
         self.energy = max(0, self.energy - ENERGY_DECAY)
         if self.energy <= 0:
             self.die()
+        self.update_visibility()
 
 
 class AIBaseAnt(BaseAnt):
@@ -244,3 +267,4 @@ class AIBaseAnt(BaseAnt):
         self.energy = max(0, self.energy - ENERGY_DECAY)
         if self.energy <= 0:
             self.die()
+        self.update_visibility()


### PR DESCRIPTION
## Summary
- control ant visibility based on terrain tiles
- apply the same logic for the queen
- fix base ant visibility calls

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867708b4b6c832eb4cfaf3b42843e69