### PR TITLE
Fix energy bar crash for removed ants

### DIFF
--- a/ant_hive/entities/base_ant.py
+++ b/ant_hive/entities/base_ant.py
@@ -142,7 +142,12 @@ class BaseAnt:
         return PALETTE.get("bar_red", "#8b0000")
 
     def update_energy_bar(self) -> None:
-        x1, y1, x2, _ = self.sim.canvas.coords(self.item)
+        if not self.alive:
+            return
+        coords = self.sim.canvas.coords(self.item)
+        if len(coords) < 4:
+            return
+        x1, y1, x2, _ = coords
         self._set_coords(self.energy_bar_bg, x1, y1 - 4, x2, y1 - 2)
         width = (self.energy / ENERGY_MAX) * (x2 - x1)
         self._set_coords(self.energy_bar, x1, y1 - 4, x1 + width, y1 - 2)

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -295,9 +295,10 @@ class AntSim:
 
     def update(self) -> None:
         self.update_lighting()
-        for ant in self.ants:
+        for ant in self.ants[:]:
             ant.update()
-            ant.update_energy_bar()
+            if ant.alive:
+                ant.update_energy_bar()
         for predator in self.predators[:]:
             predator.update()
         for egg in self.eggs[:]:


### PR DESCRIPTION
## Summary
- guard against missing canvas items in `BaseAnt.update_energy_bar`
- skip energy bar update on ants that died during the frame

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68677155b890832eb1e78aad6184ac0f