### PR TITLE
Ensure digging converts both tiles to tunnels

### DIFF
--- a/ant_hive/entities/base_ant.py
+++ b/ant_hive/entities/base_ant.py
@@ -92,6 +92,11 @@ class BaseAnt:
             if tile == TILE_SAND:
                 self.terrain.set_cell(tile_x, tile_y, TILE_TUNNEL)
                 cost += 1
+
+            orig_x = int((x1 + ANT_SIZE / 2) // TILE_SIZE)
+            orig_y = int((y1 + ANT_SIZE / 2) // TILE_SIZE)
+            if self.terrain.get_cell(orig_x, orig_y) == TILE_SAND:
+                self.terrain.set_cell(orig_x, orig_y, TILE_TUNNEL)
         if self.energy < cost:
             return
         self.energy -= cost

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -13,6 +13,7 @@ from ant_sim import (
     Terrain,
     TILE_SIZE,
     TILE_TUNNEL,
+    TILE_SAND,
 )
 
 
@@ -149,3 +150,12 @@ class TestBaseAntMovement:
         ant = BaseAnt(sim, 0, 0, energy=10)
         ant.attempt_move(TILE_SIZE, 0)
         assert ant.energy == 9
+
+    def test_sand_to_tunnel_on_move(self):
+        sim = FakeSimWithTerrain()
+        ant = BaseAnt(sim, 0, 0, energy=10)
+        assert sim.terrain.get_cell(0, 0) == TILE_SAND
+        assert sim.terrain.get_cell(1, 0) == TILE_SAND
+        ant.attempt_move(TILE_SIZE, 0)
+        assert sim.terrain.get_cell(0, 0) == TILE_TUNNEL
+        assert sim.terrain.get_cell(1, 0) == TILE_TUNNEL


### PR DESCRIPTION
## Summary
- update `BaseAnt.attempt_move` so leaving sand converts the origin tile to `TILE_TUNNEL`
- add a regression test to `tests/test_movement.py` verifying both origin and destination become tunnels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867708ca8cc832ebde738599d2e53c0