### PR TITLE
Fix indentation error in AntSim initialization

### DIFF
--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -156,8 +156,8 @@ class AntSim:
             rx = random.randint(0, self.terrain.width - 1)
             ry = random.randint(self.terrain.height // 2, self.terrain.height - 1)
             self.terrain.set_cell(rx, ry, TILE_ROCK)
-start_x = self.grid_width // 2
-start_y = self.grid_height // 2
+        start_x = self.grid_width // 2
+        start_y = self.grid_height // 2
 
         center_x = start_x * TILE_SIZE
         center_y = start_y * TILE_SIZE


### PR DESCRIPTION
## Summary
- fix indentation of hive start position in `AntSim.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867721a52c0832e88ce7eb5ac7cea72