### PR TITLE
Add mood tracking to queen

### DIFF
--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -231,6 +231,7 @@ class AntSim:
         stats = (
             f"Food: {self.food_collected}\n"
             f"Queen Hunger: {int(self.queen.hunger)}\n"
+            f"Queen Mood: {self.queen.mood}\n"
             f"Ants: {len(self.ants)}\n"
             f"Eggs: {len(self.eggs)}\n"
             f"Queen Thought: {self.queen.thought()}"

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -159,3 +159,18 @@ def test_queen_uses_openai_for_spawn(mock_create):
     sim.queen.update()
     assert len(sim.ants) == 1
     mock_create.assert_called_once()
+
+
+def test_mood_changes_with_hunger():
+    sim = FakeSim()
+    sim.queen.hunger = 25
+    sim.queen.update()
+    assert sim.queen.mood == "hungry"
+
+
+def test_mood_changes_with_predators():
+    sim = FakeSim()
+    sim.predators = [object()]
+    sim.queen.hunger = 80
+    sim.queen.update()
+    assert sim.queen.mood == "threatened"


### PR DESCRIPTION
## Summary
- track mood in the queen entity using a helper based on hunger, predators and egg count
- show mood in the queen's expression and colony stats
- include mood in AI prompt generation
- add tests for mood changes with hunger and predators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867781c991c832eaa6dedb3e70769a5