### PR TITLE
Add collapsible ant list and event log

### DIFF
--- a/ant_hive/entities/egg.py
+++ b/ant_hive/entities/egg.py
@@ -39,4 +39,6 @@ class Egg:
             self.sim.canvas.delete(self.item)
             self.sim.eggs.remove(self)
             # Delegate role selection and spawning to the queen
-            self.sim.queen.hatch_ant(int(x1), int(y1))
+            ant = self.sim.queen.hatch_ant(int(x1), int(y1))
+            if hasattr(self.sim, "log_event"):
+                self.sim.log_event(f"Egg hatched into {ant.role}")

--- a/ant_hive/entities/queen.py
+++ b/ant_hive/entities/queen.py
@@ -212,9 +212,11 @@ class Queen:
             # simulation where eggs eventually hatch.
             self.hatch_ant(x, y)
 
-    def hatch_ant(self, x: int, y: int) -> None:
+    def hatch_ant(self, x: int, y: int):
         """Hatch a new ant at the given position using weighted role probabilities."""
-        self.sim.ants.append(hatch_random_ant(self.sim, x, y))
+        ant = hatch_random_ant(self.sim, x, y)
+        self.sim.ants.append(ant)
+        return ant
 
     def begin_reproduction_cycle(self) -> None:
         if not self.ready_to_mate:

--- a/ant_hive/entities/spider.py
+++ b/ant_hive/entities/spider.py
@@ -204,6 +204,8 @@ class Spider:
                 if hasattr(ant, "image_id"):
                     self.sim.canvas.delete(ant.image_id)
                 self.sim.ants.remove(ant)
+                if hasattr(self.sim, "log_event"):
+                    self.sim.log_event(f"Spider killed {ant.role} {ant.ant_id}")
                 self.consumed += 1
                 if self.consumed % 3 == 0:
                     self.hunger += 1

--- a/ant_hive/sim.py
+++ b/ant_hive/sim.py
@@ -1,5 +1,6 @@
 import random
 import tkinter as tk
+from tkinter import ttk
 from typing import List
 import time
 
@@ -81,16 +82,19 @@ class AntSim:
         )
         self.stats_label.pack(side="top")
 
-        # Panel for individual ant statistics
-        self.ant_panel = tk.Frame(self.sidebar_frame, bg="#f9ebcc")
-        self.ant_panel.pack(side="top", fill="both", expand=True, pady=5)
-        tk.Label(
-            self.ant_panel,
-            text="Ant Stats:",
+        # Panel for individual ant statistics (collapsible)
+        self.ant_collapsed = False
+        self.ant_header = tk.Label(
+            self.sidebar_frame,
+            text="Ant Stats [-]",
             font=("Arial", 10, "bold"),
             bg="#f9ebcc",
             anchor="w",
-        ).pack(fill="x")
+        )
+        self.ant_header.pack(fill="x", pady=(5, 0))
+        self.ant_header.bind("<Button-1>", lambda _e: self.toggle_ant_panel())
+        self.ant_panel = tk.Frame(self.sidebar_frame, bg="#f9ebcc")
+        self.ant_panel.pack(side="top", fill="both", expand=True, pady=5)
         self.ant_canvas = tk.Canvas(
             self.ant_panel,
             bg="#f9ebcc",
@@ -137,6 +141,10 @@ class AntSim:
             font=MONO_FONT,
         )
         self.colony_stats_label.pack(fill="x")
+        self.event_log = tk.Text(
+            self.colony_panel, height=6, state="disabled", bg="#f9ebcc", wrap="word"
+        )
+        self.event_log.pack(fill="both", pady=(5, 0))
         self.spawn_button.bind("<ButtonPress-1>", self.start_place_food)
         self.canvas.bind("<Button-1>", self.place_food)
         self.placing_food = False
@@ -236,6 +244,23 @@ class AntSim:
             f"Queen Thought: {self.queen.thought()}"
         )
         self.colony_stats_label.configure(text=stats)
+
+    def log_event(self, message: str) -> None:
+        if not hasattr(self, "event_log"):
+            return
+        self.event_log.configure(state="normal")
+        self.event_log.insert("end", message + "\n")
+        self.event_log.see("end")
+        self.event_log.configure(state="disabled")
+
+    def toggle_ant_panel(self) -> None:
+        if self.ant_collapsed:
+            self.ant_panel.pack(side="top", fill="both", expand=True, pady=5)
+            self.ant_header.configure(text="Ant Stats [-]")
+        else:
+            self.ant_panel.pack_forget()
+            self.ant_header.configure(text="Ant Stats [+]")
+        self.ant_collapsed = not self.ant_collapsed
 
     def start_place_food(self, _event) -> None:
         self.placing_food = True

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,100 @@
+from ant_sim import Queen, Spider, BaseAnt, ANT_SIZE
+
+class FakeText:
+    def __init__(self):
+        self.lines = []
+    def insert(self, index, text):
+        self.lines.append(text.strip())
+    def see(self, index):
+        pass
+    def configure(self, **kwargs):
+        pass
+
+class FakeCanvas:
+    def __init__(self):
+        self.objects = {}
+        self.next_id = 1
+    def _create_item(self, coords):
+        item_id = self.next_id
+        self.next_id += 1
+        self.objects[item_id] = coords[:]
+        return item_id
+    def create_oval(self, x1, y1, x2, y2, fill=None, **kw):
+        return self._create_item([x1, y1, x2, y2])
+    def create_rectangle(self, x1, y1, x2, y2, fill=None, **kw):
+        return self._create_item([x1, y1, x2, y2])
+    def create_text(self, *args, **kw):
+        return self._create_item([0,0,0,0])
+    def create_image(self, x, y, image=None, anchor="nw"):
+        return self._create_item([x, y, x + ANT_SIZE, y + ANT_SIZE])
+    def delete(self, item_id):
+        self.objects.pop(item_id, None)
+    def after(self, delay, func=None):
+        if func:
+            func()
+    def move(self, item_id, dx, dy):
+        x1, y1, x2, y2 = self.objects[item_id]
+        self.objects[item_id] = [x1 + dx, y1 + dy, x2 + dx, y2 + dy]
+    def coords(self, item_id, *args):
+        if args:
+            self.objects[item_id] = list(args)
+        return self.objects[item_id]
+    def itemconfigure(self, item_id, **kw):
+        pass
+
+class FakeSimEgg:
+    def __init__(self):
+        self.canvas = FakeCanvas()
+        self.event_log = FakeText()
+        self.ants = []
+        self.eggs = []
+        self.food_collected = 0
+        self.queen_fed = 0
+        self.queen = Queen(self, 0, 0)
+    def move_food(self):
+        pass
+    def sparkle(self, x, y):
+        pass
+    def get_coords(self, item):
+        return self.canvas.coords(item)
+    def check_collision(self, a, b):
+        ax1, ay1, ax2, ay2 = self.get_coords(a)
+        bx1, by1, bx2, by2 = self.get_coords(b)
+        return ax1 < bx2 and ax2 > bx1 and ay1 < by2 and ay2 > by1
+    def log_event(self, msg):
+        self.event_log.insert("end", msg)
+
+class FakeSimSpider:
+    def __init__(self):
+        self.canvas = FakeCanvas()
+        self.event_log = FakeText()
+        self.ants = []
+        self.predators = []
+        self.is_night = True
+    def get_coords(self, item):
+        return self.canvas.coords(item)
+    def check_collision(self, a, b):
+        ax1, ay1, ax2, ay2 = self.get_coords(a)
+        bx1, by1, bx2, by2 = self.get_coords(b)
+        return ax1 < bx2 and ax2 > bx1 and ay1 < by2 and ay2 > by1
+    def log_event(self, msg):
+        self.event_log.insert("end", msg)
+
+
+def test_egg_hatching_logs_event():
+    sim = FakeSimEgg()
+    sim.queen.lay_egg(0, 0)
+    egg = sim.eggs[0]
+    egg.hatch_time = 1
+    egg.update()
+    assert any("Egg hatched" in line for line in sim.event_log.lines)
+
+
+def test_spider_kill_logs_event():
+    sim = FakeSimSpider()
+    spider = Spider(sim, 0, 0)
+    ant = BaseAnt(sim, 0, 0)
+    ant.energy = 0
+    sim.ants.append(ant)
+    spider.attack_ants()
+    assert any("Spider killed" in line for line in sim.event_log.lines)


### PR DESCRIPTION
## Summary
- make ant stats collapsible with a header
- add a Text based event log below colony stats
- log egg hatch and spider kills
- expose events via `AntSim.log_event`
- return new ant from `Queen.hatch_ant`
- test logging of egg hatching and spider kills

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867783fa150832eb2898abf85e06b29